### PR TITLE
ARM: make PLT pointer-to-word conversions explicit.

### DIFF
--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -2048,7 +2048,7 @@ init_plt (MonoAotModule *info)
 	 for (i = 1; i < n_entries; ++i)
 		 /* Each PLT entry is 8 bytes long, the jump target is at offset 4 */
 		 /* Each default PLT target is 12 bytes long */
-		 ((guint32*)info->plt)[(i * 2) + 1] = (guint8*)info->plt_end + ((i - 1) * 12);
+		 ((guint32*)info->plt)[(i * 2) + 1] = (guint32)(guintptr)((guint8*)info->plt_end + ((i - 1) * 12));
 #else
 	g_assert_not_reached ();
 #endif

--- a/mono/mini/tramp-arm.c
+++ b/mono/mini/tramp-arm.c
@@ -112,7 +112,7 @@ mono_arch_patch_plt_entry (guint8 *code, guint8 *addr)
 		((guint32*)code) [0] = ins;
 	else
 		/* Patch the jump address */
-		((guint32*)code) [1] = addr;
+		((guint32*)code) [1] = (guint32)(guintptr)addr;
 	mono_arch_flush_icache ((char*)code, 4);
 }
 


### PR DESCRIPTION
ARM PLT setup stores target addresses into 32-bit PLT words. That is the intended representation for this 32-bit ARM code path, but the source assigned "guint8*" expressions directly to "guint32" lvalues.

Older compilers accepted this as an implicit pointer-to-int conversion.  Modern GCC diagnoses it as an int-conversion *error*.  Cast through `guintptr` first, the GLib integer type meant to carry a pointer value, and then narrow to `guint32` to preserve the actual 32-bit PLT word format used by this ARM backend.

This does not change the PLT layout or generated value.  It only makes the existing 32-bit ARM assumption explicit enough for current C compilers.