### PR TITLE
Fix X11 text input for unmapped keyboard layouts

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/KeyboardLayouts.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/KeyboardLayouts.cs
@@ -2080,6 +2080,7 @@ namespace System.Windows.Forms
 			VK_ICO_HELP = 0xE3,
 			VK_ICO_00 = 0xE4,
 			VK_PROCESSKEY = 0xE5,
+			VK_PACKET = 0xE7,
 			VK_OEM_ATTN = 0xF0,
 			VK_OEM_COPY = 0xF2,
 			VK_OEM_AUTO = 0xF3,

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/X11Keyboard.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/X11Keyboard.cs
@@ -392,9 +392,9 @@ namespace System.Windows.Forms {
 
 			string text = msg.refobject as string;
 			if (!String.IsNullOrEmpty (text)) {
-				Msg message = (msg.message == Msg.WM_KEYDOWN ? Msg.WM_CHAR : Msg.WM_SYSCHAR);
+				Msg text_message = (msg.message == Msg.WM_KEYDOWN ? Msg.WM_CHAR : Msg.WM_SYSCHAR);
 				foreach (char c in text)
-					XplatUI.PostMessage (msg.hwnd, message, (IntPtr) c, msg.lParam);
+					XplatUI.PostMessage (msg.hwnd, text_message, (IntPtr) c, msg.lParam);
 				return true;
 			}
 

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/X11Keyboard.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/X11Keyboard.cs
@@ -328,10 +328,16 @@ namespace System.Windows.Forms {
 				return;
 			}
 
+			string text = null;
+			if (xevent.type == XEventName.KeyPress && ascii_chars != 0)
+				text = lookup_buffer.ToString (0, lookup_buffer.Length);
+
 			AltGrMask = xevent.KeyEvent.state & (0x6000 | (int) KeyMasks.ModMasks);
 			int vkey = EventToVkey (xevent);
 			if (vkey == 0 && ascii_chars != 0) {
-				vkey = (int) VirtualKeys.VK_NONAME;
+				vkey = (int) VirtualKeys.VK_PACKET;
+			} else {
+				text = null;
 			}
 
 			if (FilterKey (xevent, vkey))
@@ -363,7 +369,7 @@ namespace System.Windows.Forms {
 					dw_flags |= KeybdEventFlags.KeyUp;
 				if ((vkey & 0x100) != 0)
 					dw_flags |= KeybdEventFlags.ExtendedKey;
-				msg = SendKeyboardInput ((VirtualKeys) (vkey & 0xFF), bscan, xevent.KeyEvent.keycode, dw_flags, event_time);
+				msg = SendKeyboardInput ((VirtualKeys) (vkey & 0xFF), bscan, xevent.KeyEvent.keycode, dw_flags, event_time, text);
 				msg.hwnd = hwnd;
 				break;
 			}
@@ -383,6 +389,14 @@ namespace System.Windows.Forms {
 
 			if (msg.message != Msg.WM_KEYDOWN && msg.message != Msg.WM_SYSKEYDOWN)
 				return res;
+
+			string text = msg.refobject as string;
+			if (!String.IsNullOrEmpty (text)) {
+				Msg message = (msg.message == Msg.WM_KEYDOWN ? Msg.WM_CHAR : Msg.WM_SYSCHAR);
+				foreach (char c in text)
+					XplatUI.PostMessage (msg.hwnd, message, (IntPtr) c, msg.lParam);
+				return true;
+			}
 
 			if ((key_state_table [(int) VirtualKeys.VK_MENU] & 0x80) != 0 && msg.wParam != (IntPtr) 0x12)
 				menu_state = true;
@@ -565,6 +579,11 @@ namespace System.Windows.Forms {
 
 		private MSG SendKeyboardInput (VirtualKeys vkey, int scan, int keycode, KeybdEventFlags dw_flags, uint time)
 		{
+			return SendKeyboardInput (vkey, scan, keycode, dw_flags, time, null);
+		}
+
+		private MSG SendKeyboardInput (VirtualKeys vkey, int scan, int keycode, KeybdEventFlags dw_flags, uint time, string text)
+		{
 			Msg message;
 
 			if ((dw_flags & KeybdEventFlags.KeyUp) != 0) {
@@ -586,6 +605,7 @@ namespace System.Windows.Forms {
 			msg.message = message;
 			msg.wParam = (IntPtr) vkey;
 			msg.lParam = GenerateLParam (msg, keycode);
+			msg.refobject = text;
 			return msg;
 		}
 

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIStructs.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIStructs.cs
@@ -645,6 +645,7 @@ namespace System.Windows.Forms
 		VK_ICO_HELP		= 0xE3,
 		VK_ICO_00		= 0xE4,
 		VK_PROCESSKEY		= 0xE5,
+		VK_PACKET		= 0xE7,
 		VK_OEM_ATTN		= 0xF0,
 		VK_OEM_COPY		= 0xF2,
 		VK_OEM_AUTO		= 0xF3,


### PR DESCRIPTION
Fixes #12

GitPay task: https://gitpay.me/#/task/1639

The X11 keyboard path can receive text from `XLookupString` even when Mono cannot map the physical keycode to a WinForms virtual key. Today that falls back to `VK_NONAME`, then `TranslateMessage` calls `ToUnicode` with a synthetic event that has no real keycode, so the character is lost.

This preserves the original lookup text on the generated keydown message only for unmapped virtual keys, then posts those cached characters from `TranslateMessage`. Mapped keys continue through the existing `ToUnicode` path.

This should cover the French BEPO top-row number case where some base keysyms are not represented in Mono's static keyboard layout tables, but `XLookupString` has already returned the typed digit.

Validation:
- `git diff --check`

I could not run the full Linux/X11 reproduction in this Windows environment, so this still needs a runtime smoke test with a French BEPO layout.