### PR TITLE
[WinForms]: Make Control.CreateGraphics driver-routable.

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/Control.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/Control.cs
@@ -3603,7 +3603,7 @@ namespace System.Windows.Forms
 			if (!IsHandleCreated) {
 				this.CreateHandle();
 			}
-			return Graphics.FromHwnd(this.window.Handle);
+			return XplatUI.CreateGraphics (this.window.Handle);
 		}
 
 		public DragDropEffects DoDragDrop(object data, DragDropEffects allowedEffects) {

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUI.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUI.cs
@@ -789,6 +789,12 @@ namespace System.Windows.Forms {
 		}
 
 
+		internal static Graphics CreateGraphics (IntPtr handle)
+		{
+			DriverDebug ("CreateGraphics ({0}): Called", Window (handle));
+			return driver.CreateGraphics (handle);
+		}
+
 		internal static bool IsEnabled (IntPtr handle)
 		{
 			#if DriverDebug || DriverDebugState

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIDriver.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIDriver.cs
@@ -330,6 +330,10 @@ namespace System.Windows.Forms {
 		internal abstract void SetModal(IntPtr handle, bool Modal);
 		internal abstract void Invalidate(IntPtr handle, Rectangle rc, bool clear);
 		internal abstract void InvalidateNC(IntPtr handle);
+		internal virtual Graphics CreateGraphics (IntPtr handle)
+		{
+			return Graphics.FromHwnd (handle);
+		}
 		internal abstract IntPtr DefWndProc(ref Message msg);
 		internal abstract void HandleException(Exception e);
 		internal abstract void DoEvents();


### PR DESCRIPTION
Previously, we called Graphics.FromHwnd directly, which hard-wired System.Drawing/libgdiplus to the native HWND path and bypassed XplatUIDriver.  That breaks loadable backends whose native handles are not libgdiplus HWNDs.

Add an explicit virtual XplatUIDriver.CreateGraphics hook with the existing Graphics.FromHwnd behavior as the default, then route Control.CreateGraphics through XplatUI.  Existing backends keep the same behavior unless they override the hook; non-HWND backends get a compile-time checked extension point.

This is a small extension to the ability introduced by https://github.com/mono/mono/pull/7100

My work in progress using this: https://github.com/daym/WaylandDriver