### PR TITLE
Set popup owners of ComboBox and ContextMenu

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ComboBox.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ComboBox.cs
@@ -2442,8 +2442,8 @@ namespace System.Windows.Forms
 					if (owner == null || owner.DropDownStyle == ComboBoxStyle.Simple)
 						return cp;
 
-					cp.Style ^= (int)WindowStyles.WS_CHILD;
-					cp.Style ^= (int)WindowStyles.WS_VISIBLE;
+					cp.Style &= ~(int)WindowStyles.WS_CHILD;
+					cp.Style &= ~(int)WindowStyles.WS_VISIBLE;
 					cp.Style |= (int)WindowStyles.WS_POPUP;
 					cp.ExStyle |= (int) WindowExStyles.WS_EX_TOOLWINDOW | (int) WindowExStyles.WS_EX_TOPMOST;
 					return cp;
@@ -2778,8 +2778,8 @@ namespace System.Windows.Forms
 				Rectangle scrn_rect = Screen.FromControl (owner).Bounds;
 				if (this.Location.Y + this.Height >= scrn_rect.Bottom)
 					this.Location = new Point (this.Location.X, this.Location.Y - (this.Height + owner.TextArea.Height));
-				Show ();
 				XplatUI.SetOwner (Handle, owner.Handle);
+				Show ();
 
 				Refresh ();
 				owner.OnDropDown (EventArgs.Empty);

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/MenuAPI.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/MenuAPI.cs
@@ -285,6 +285,7 @@ namespace System.Windows.Forms {
 			
 			menu.Wnd = new PopUpWindow (tracker.GrabControl, menu);
 			menu.Wnd.Location =  menu.Wnd.PointToClient (pnt);
+			XplatUI.SetOwner (menu.Wnd.Handle, tracker.GrabControl.Handle);
 			((PopUpWindow)menu.Wnd).ShowWindow ();
 
 			bool no_quit = true;
@@ -422,6 +423,7 @@ namespace System.Windows.Forms {
 			puw.Location = pnt;
 			item.Wnd = puw;
 
+			XplatUI.SetOwner (puw.Handle, GrabControl.Handle);
 			puw.ShowWindow ();
 			if (menu.Tracker.ShowSubPopupEvent != null)
 				menu.Tracker.ShowSubPopupEvent (this, new SubPopupEventArgs (item));


### PR DESCRIPTION
A future Wayland backend must choose `xdg_popup` vs `xdg_toplevel` before the surface is first committed, and `xdg_popup` needs the parent surface up front. Set the native owner before showing both the top-level context menu popup and submenu popups.

For http://www.github.com/daym/WaylandDriver .
