### PR TITLE
Make Dispose(false) not mutate collections

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/Form.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/Form.cs
@@ -1949,16 +1949,19 @@ namespace System.Windows.Forms {
 
 		protected override void Dispose(bool disposing)
 		{
-			if (owned_forms != null) {
-				for (int i = 0; i < owned_forms.Count; i++)
-					((Form)owned_forms[i]).Owner = null;
+			if (disposing) {
+				if (owned_forms != null) {
+					for (int i = 0; i < owned_forms.Count; i++)
+						((Form)owned_forms[i]).Owner = null;
 
-				owned_forms.Clear ();
+					owned_forms.Clear ();
+				}
+				Owner = null;
 			}
-			Owner = null;
 			base.Dispose (disposing);
 			
-			Application.RemoveForm (this);
+			if (disposing)
+				Application.RemoveForm (this);
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Advanced)]

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ToolStripControlHost.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ToolStripControlHost.cs
@@ -292,7 +292,7 @@ namespace System.Windows.Forms
 		{
 			base.Dispose (disposing);
 
-			if (control.Created && !control.IsDisposed)
+			if (disposing && control.Created && !control.IsDisposed)
 				control.Dispose ();
 		}
 		


### PR DESCRIPTION
This... was not fun to debug.

Dispose(false) shouldn't mutate things, causing who knows what while the finalizer is running.
