### PR TITLE
Preserve System.ValueTuple types in linker descriptor

### DIFF
--- a/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
+++ b/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
@@ -850,5 +850,17 @@
 		<type fullname="Mono.ValueTuple`3" preserve="fields"/>
 		<type fullname="Mono.ValueTuple`4" preserve="fields"/>
 		<type fullname="Mono.ValueTuple`5" preserve="fields"/>
+
+		<type fullname="System.ValueTuple" preserve="all"/>
+		<type fullname="System.ValueTuple`1" preserve="all"/>
+		<type fullname="System.ValueTuple`2" preserve="all"/>
+		<type fullname="System.ValueTuple`3" preserve="all"/>
+		<type fullname="System.ValueTuple`4" preserve="all"/>
+		<type fullname="System.ValueTuple`5" preserve="all"/>
+		<type fullname="System.ValueTuple`6" preserve="all"/>
+		<type fullname="System.ValueTuple`7" preserve="all"/>
+		<type fullname="System.ValueTuple`8" preserve="all"/>
+		<type fullname="System.TupleExtensions" preserve="all"/>
+		<type fullname="System.Runtime.CompilerServices.TupleElementNamesAttribute" preserve="all"/>
 	</assembly>
 </linker>


### PR DESCRIPTION
**Summary**
`System.ValueTuple` types (arities 0–8) are compiled into mscorlib.dll from `external/corefx/src/Common/src/CoreLib/System/ValueTuple.cs` but are stripped by ILinker because they're not listed in the linker descriptor. Applications targeting .NET 4.7+ that use value tuples (e.g. xalia, Proton's gamepad helper) crash with:
```
System.TypeLoadException: Could not load type 'System.ValueTuple`3'
  from assembly 'mscorlib, Version=4.0.0.0, Culture=neutral,
  PublicKeyToken=b77a5c561934e089'.
```

**What this does**
Adds the following types to `mcs/class/corlib/LinkerDescriptor/mscorlib.xml` with `preserve="all"`:
- `System.ValueTuple` (arities 0–8)
- `System.TupleExtensions`
- `System.Runtime.CompilerServices.TupleElementNamesAttribute`
These types already exist in the source and are forwarded from `Facades/System.ValueTuple`, `Facades/System.Runtime`, and `Facades/netstandard` — they just needed to survive the linker.

**Verification**
`strings mono/mcs/class/corlib/bin/mscorlib.dll | grep "^System.ValueTuple"`
Before: only `Mono.ValueTuple` (JIT internal) types present.
After: all `System.ValueTuple` types present with `preserve="all"`.