### PR TITLE
Mono 6.14 ARM runtime/JIT correctness fixes.

### DIFF
--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -1089,29 +1089,47 @@ add_general (guint *gr, guint *stack_size, ArgInfo *ainfo, gboolean simple)
 			split = TRUE;
 
 		ainfo->size = 8;
-		if (*gr == ARMREG_R3 && split) {
+		if (eabi_supported) {
+			/*
+			 * AAPCS requires 64-bit core-register arguments to start in an
+			 * even-numbered argument register.  If alignment skips past r3,
+			 * there is no remaining argument register; the whole argument belongs
+			 * on the stack.  The existing r3/stack split remains correct for
+			 * 4-byte-aligned ABIs such as Darwin/iOS ARM.
+			 */
+			if (i8_align == 8 && ((*gr) & 1))
+				(*gr) ++;
+			if (*gr > ARMREG_R3) {
+				if (i8_align == 8) {
+					*stack_size += 7;
+					*stack_size &= ~7;
+				}
+				ainfo->offset = *stack_size;
+				ainfo->reg = ARMREG_SP; /* in the caller */
+				ainfo->storage = RegTypeBase;
+				*stack_size += 8;
+			} else if (*gr == ARMREG_R3 && i8_align == 4) {
+				/* first word in r3 and the second on the stack */
+				ainfo->offset = *stack_size;
+				ainfo->reg = ARMREG_SP; /* in the caller */
+				ainfo->storage = RegTypeBaseGen;
+				*stack_size += 4;
+			} else {
+				ainfo->storage = RegTypeIRegPair;
+				ainfo->reg = *gr;
+			}
+		} else if (*gr == ARMREG_R3 && split) {
 			/* first word in r3 and the second on the stack */
 			ainfo->offset = *stack_size;
 			ainfo->reg = ARMREG_SP; /* in the caller */
 			ainfo->storage = RegTypeBaseGen;
 			*stack_size += 4;
 		} else if (*gr >= ARMREG_R3) {
-			if (eabi_supported) {
-				/* darwin aligns longs to 4 byte only */
-				if (i8_align == 8) {
-					*stack_size += 7;
-					*stack_size &= ~7;
-				}
-			}
 			ainfo->offset = *stack_size;
 			ainfo->reg = ARMREG_SP; /* in the caller */
 			ainfo->storage = RegTypeBase;
 			*stack_size += 8;
 		} else {
-			if (eabi_supported) {
-				if (i8_align == 8 && ((*gr) & 1))
-					(*gr) ++;
-			}
 			ainfo->storage = RegTypeIRegPair;
 			ainfo->reg = *gr;
 		}


### PR DESCRIPTION
Repair an ARM EABI argument placement invariant in Mono 6.14.

Mono 6.14 has a real ARM_FPU_VFP_HARD path: configure.ac detects __ARM_PCS_VFP, mini-arm.h accepts ARM_FPU_VFP_HARD, and mini-arm.c has hard-float argument assignment.

ARM EABI requires 64-bit core-register arguments to start in an even-numbered argument register.  If alignment skips past r3, there is no r4 argument register; the whole 64-bit argument belongs on the stack.  The old argument placement could align r3 to r4 and still record the argument as register-passed, corrupting managed calls with an int64 or non-VFP double after preceding register arguments.

This intentionally preserves the old split r3/stack case for 4-byte-aligned ABIs, including Darwin/iOS-style ARM handling.  The stack-only change is for the 8-byte-aligned EABI case used by armhf after register alignment consumes the last available argument register.