### PR TITLE
Mono 2.6.4 ARM EABI floating-point ABI fixes.

### DIFF
--- a/mono/metadata/decimal.h
+++ b/mono/metadata/decimal.h
@@ -31,7 +31,7 @@ typedef struct
 
 /* function prototypes */
 gint32 mono_decimalIncr(/*[In, Out]*/decimal_repr* pA, /*[In]*/decimal_repr* pB) MONO_INTERNAL;
-gint32 mono_double2decimal(/*[Out]*/decimal_repr* pA, double val, gint32 digits) MONO_INTERNAL;
+gint32 MONO_ICALL_FP_ABI mono_double2decimal(/*[Out]*/decimal_repr* pA, double val, gint32 digits) MONO_INTERNAL;
 gint32 mono_decimal2UInt64(/*[In]*/decimal_repr* pD, guint64* pResult) MONO_INTERNAL;
 gint32 mono_decimal2Int64(/*[In]*/decimal_repr* pD, gint64* pResult) MONO_INTERNAL;
 void mono_decimalFloorAndTrunc(/*[In, Out]*/decimal_repr* pD, gint32 floorFlag) MONO_INTERNAL;
@@ -40,7 +40,7 @@ gint32 mono_decimalMult(/*[In, Out]*/decimal_repr* pA, /*[In]*/decimal_repr* pB)
 gint32 mono_decimalDiv(/*[Out]*/decimal_repr* pC, /*[In]*/decimal_repr* pA, /*[In]*/decimal_repr* pB) MONO_INTERNAL;
 gint32 mono_decimalIntDiv(/*[Out]*/decimal_repr* pC, /*[In]*/decimal_repr* pA, /*[In]*/decimal_repr* pB) MONO_INTERNAL;
 gint32 mono_decimalCompare(/*[In]*/decimal_repr* pA, /*[In]*/decimal_repr* pB) MONO_INTERNAL;
-double mono_decimal2double(/*[In]*/decimal_repr* pA) MONO_INTERNAL;
+double MONO_ICALL_FP_ABI mono_decimal2double(/*[In]*/decimal_repr* pA) MONO_INTERNAL;
 gint32 mono_decimalSetExponent(/*[In, Out]*/decimal_repr* pA, gint32 texp) MONO_INTERNAL;
 
 gint32 mono_string2decimal(/*[Out]*/decimal_repr* pA, /*[In]*/MonoString* s, gint32 decrDecimal, gint32 sign) MONO_INTERNAL;

--- a/mono/metadata/sysmath.h
+++ b/mono/metadata/sysmath.h
@@ -14,53 +14,53 @@
 #include <glib.h>
 #include "mono/utils/mono-compiler.h"
 
-extern gdouble ves_icall_System_Math_Floor (gdouble x) MONO_INTERNAL;
-extern gdouble ves_icall_System_Math_Round (gdouble x) MONO_INTERNAL;
-extern gdouble ves_icall_System_Math_Round2 (gdouble value, gint32 digits, gboolean away_from_zero) MONO_INTERNAL;
+extern gdouble MONO_ICALL_FP_ABI ves_icall_System_Math_Floor (gdouble x) MONO_INTERNAL;
+extern gdouble MONO_ICALL_FP_ABI ves_icall_System_Math_Round (gdouble x) MONO_INTERNAL;
+extern gdouble MONO_ICALL_FP_ABI ves_icall_System_Math_Round2 (gdouble value, gint32 digits, gboolean away_from_zero) MONO_INTERNAL;
 
 extern gdouble 
-ves_icall_System_Math_Sin (gdouble x) MONO_INTERNAL;
+MONO_ICALL_FP_ABI ves_icall_System_Math_Sin (gdouble x) MONO_INTERNAL;
 
 extern gdouble 
-ves_icall_System_Math_Cos (gdouble x) MONO_INTERNAL;
+MONO_ICALL_FP_ABI ves_icall_System_Math_Cos (gdouble x) MONO_INTERNAL;
 
 extern gdouble 
-ves_icall_System_Math_Tan (gdouble x) MONO_INTERNAL;
+MONO_ICALL_FP_ABI ves_icall_System_Math_Tan (gdouble x) MONO_INTERNAL;
 
 extern gdouble 
-ves_icall_System_Math_Sinh (gdouble x) MONO_INTERNAL;
+MONO_ICALL_FP_ABI ves_icall_System_Math_Sinh (gdouble x) MONO_INTERNAL;
 
 extern gdouble 
-ves_icall_System_Math_Cosh (gdouble x) MONO_INTERNAL;
+MONO_ICALL_FP_ABI ves_icall_System_Math_Cosh (gdouble x) MONO_INTERNAL;
 
 extern gdouble 
-ves_icall_System_Math_Tanh (gdouble x) MONO_INTERNAL;
+MONO_ICALL_FP_ABI ves_icall_System_Math_Tanh (gdouble x) MONO_INTERNAL;
 
 extern gdouble 
-ves_icall_System_Math_Acos (gdouble x) MONO_INTERNAL;
+MONO_ICALL_FP_ABI ves_icall_System_Math_Acos (gdouble x) MONO_INTERNAL;
 
 extern gdouble 
-ves_icall_System_Math_Asin (gdouble x) MONO_INTERNAL;
+MONO_ICALL_FP_ABI ves_icall_System_Math_Asin (gdouble x) MONO_INTERNAL;
 
 extern gdouble 
-ves_icall_System_Math_Atan (gdouble x) MONO_INTERNAL;
+MONO_ICALL_FP_ABI ves_icall_System_Math_Atan (gdouble x) MONO_INTERNAL;
 
 extern gdouble 
-ves_icall_System_Math_Atan2 (gdouble y, gdouble x) MONO_INTERNAL;
+MONO_ICALL_FP_ABI ves_icall_System_Math_Atan2 (gdouble y, gdouble x) MONO_INTERNAL;
 
 extern gdouble 
-ves_icall_System_Math_Exp (gdouble x) MONO_INTERNAL;
+MONO_ICALL_FP_ABI ves_icall_System_Math_Exp (gdouble x) MONO_INTERNAL;
 
 extern gdouble 
-ves_icall_System_Math_Log (gdouble x) MONO_INTERNAL;
+MONO_ICALL_FP_ABI ves_icall_System_Math_Log (gdouble x) MONO_INTERNAL;
 
 extern gdouble 
-ves_icall_System_Math_Log10 (gdouble x) MONO_INTERNAL;
+MONO_ICALL_FP_ABI ves_icall_System_Math_Log10 (gdouble x) MONO_INTERNAL;
 
 extern gdouble 
-ves_icall_System_Math_Pow (gdouble x, gdouble y) MONO_INTERNAL;
+MONO_ICALL_FP_ABI ves_icall_System_Math_Pow (gdouble x, gdouble y) MONO_INTERNAL;
 
 extern gdouble 
-ves_icall_System_Math_Sqrt (gdouble x) MONO_INTERNAL;
+MONO_ICALL_FP_ABI ves_icall_System_Math_Sqrt (gdouble x) MONO_INTERNAL;
 
 #endif

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -97,15 +97,15 @@ gint32 ves_icall_System_Threading_Interlocked_Exchange_Int(gint32 *location, gin
 gint64 ves_icall_System_Threading_Interlocked_Exchange_Long(gint64 *location, gint64 value) MONO_INTERNAL;
 MonoObject *ves_icall_System_Threading_Interlocked_Exchange_Object(MonoObject **location, MonoObject *value) MONO_INTERNAL;
 gpointer ves_icall_System_Threading_Interlocked_Exchange_IntPtr(gpointer *location, gpointer value) MONO_INTERNAL;
-gfloat ves_icall_System_Threading_Interlocked_Exchange_Single(gfloat *location, gfloat value) MONO_INTERNAL;
-gdouble ves_icall_System_Threading_Interlocked_Exchange_Double(gdouble *location, gdouble value) MONO_INTERNAL;
+gfloat MONO_ICALL_FP_ABI ves_icall_System_Threading_Interlocked_Exchange_Single(gfloat *location, gfloat value) MONO_INTERNAL;
+gdouble MONO_ICALL_FP_ABI ves_icall_System_Threading_Interlocked_Exchange_Double(gdouble *location, gdouble value) MONO_INTERNAL;
 
 gint32 ves_icall_System_Threading_Interlocked_CompareExchange_Int(gint32 *location, gint32 value, gint32 comparand) MONO_INTERNAL;
 gint64 ves_icall_System_Threading_Interlocked_CompareExchange_Long(gint64 *location, gint64 value, gint64 comparand) MONO_INTERNAL;
 MonoObject *ves_icall_System_Threading_Interlocked_CompareExchange_Object(MonoObject **location, MonoObject *value, MonoObject *comparand) MONO_INTERNAL;
 gpointer ves_icall_System_Threading_Interlocked_CompareExchange_IntPtr(gpointer *location, gpointer value, gpointer comparand) MONO_INTERNAL;
-gfloat ves_icall_System_Threading_Interlocked_CompareExchange_Single(gfloat *location, gfloat value, gfloat comparand) MONO_INTERNAL;
-gdouble ves_icall_System_Threading_Interlocked_CompareExchange_Double(gdouble *location, gdouble value, gdouble comparand) MONO_INTERNAL;
+gfloat MONO_ICALL_FP_ABI ves_icall_System_Threading_Interlocked_CompareExchange_Single(gfloat *location, gfloat value, gfloat comparand) MONO_INTERNAL;
+gdouble MONO_ICALL_FP_ABI ves_icall_System_Threading_Interlocked_CompareExchange_Double(gdouble *location, gdouble value, gdouble comparand) MONO_INTERNAL;
 MonoObject* ves_icall_System_Threading_Interlocked_CompareExchange_T(MonoObject **location, MonoObject *value, MonoObject *comparand) MONO_INTERNAL;
 MonoObject* ves_icall_System_Threading_Interlocked_Exchange_T(MonoObject **location, MonoObject *value) MONO_INTERNAL;
 

--- a/mono/mini/jit-icalls.c
+++ b/mono/mini/jit-icalls.c
@@ -329,12 +329,20 @@ mono_imul_ovf_un (guint32 a, guint32 b)
 #endif
 
 #if defined(MONO_ARCH_EMULATE_MUL_DIV) || defined(MONO_ARCH_SOFT_FLOAT)
-double
+double MONO_JIT_ICALL_FP_ABI
 mono_fdiv (double a, double b)
 {
 	MONO_ARCH_SAVE_REGS;
 
 	return a / b;
+}
+#endif
+
+#if defined(__arm__) && defined(__ARM_PCS_VFP)
+double MONO_JIT_ICALL_FP_ABI
+mono_frem (double a, double b)
+{
+	return fmod (a, b);
 }
 #endif
 
@@ -437,169 +445,169 @@ mono_lshr (gint64 a, gint32 shamt)
 
 #ifdef MONO_ARCH_SOFT_FLOAT
 
-double
+double MONO_JIT_ICALL_FP_ABI
 mono_fsub (double a, double b)
 {
 	return a - b;
 }
 
-double
+double MONO_JIT_ICALL_FP_ABI
 mono_fadd (double a, double b)
 {
 	return a + b;
 }
 
-double
+double MONO_JIT_ICALL_FP_ABI
 mono_fmul (double a, double b)
 {
 	return a * b;
 }
 
-double
+double MONO_JIT_ICALL_FP_ABI
 mono_fneg (double a)
 {
 	return -a;
 }
 
-double
+double MONO_JIT_ICALL_FP_ABI
 mono_fconv_r4 (double a)
 {
 	return (float)a;
 }
 
-double
+double MONO_JIT_ICALL_FP_ABI
 mono_conv_to_r8 (int a)
 {
 	return (double)a;
 }
 
-double
+double MONO_JIT_ICALL_FP_ABI
 mono_conv_to_r4 (int a)
 {
 	return (double)(float)a;
 }
 
-gint8
+gint8 MONO_JIT_ICALL_FP_ABI
 mono_fconv_i1 (double a)
 {
 	return (gint8)a;
 }
 
-gint16
+gint16 MONO_JIT_ICALL_FP_ABI
 mono_fconv_i2 (double a)
 {
 	return (gint16)a;
 }
 
-gint32
+gint32 MONO_JIT_ICALL_FP_ABI
 mono_fconv_i4 (double a)
 {
 	return (gint32)a;
 }
 
-guint8
+guint8 MONO_JIT_ICALL_FP_ABI
 mono_fconv_u1 (double a)
 {
 	return (guint8)a;
 }
 
-guint16
+guint16 MONO_JIT_ICALL_FP_ABI
 mono_fconv_u2 (double a)
 {
 	return (guint16)a;
 }
 
-gboolean
+gboolean MONO_JIT_ICALL_FP_ABI
 mono_fcmp_eq (double a, double b)
 {
 	return a == b;
 }
 
-gboolean
+gboolean MONO_JIT_ICALL_FP_ABI
 mono_fcmp_ge (double a, double b)
 {
 	return a >= b;
 }
 
-gboolean
+gboolean MONO_JIT_ICALL_FP_ABI
 mono_fcmp_gt (double a, double b)
 {
 	return a > b;
 }
 
-gboolean
+gboolean MONO_JIT_ICALL_FP_ABI
 mono_fcmp_le (double a, double b)
 {
 	return a <= b;
 }
 
-gboolean
+gboolean MONO_JIT_ICALL_FP_ABI
 mono_fcmp_lt (double a, double b)
 {
 	return a < b;
 }
 
-gboolean
+gboolean MONO_JIT_ICALL_FP_ABI
 mono_fcmp_ne_un (double a, double b)
 {
 	return isunordered (a, b) || a != b;
 }
 
-gboolean
+gboolean MONO_JIT_ICALL_FP_ABI
 mono_fcmp_ge_un (double a, double b)
 {
 	return isunordered (a, b) || a >= b;
 }
 
-gboolean
+gboolean MONO_JIT_ICALL_FP_ABI
 mono_fcmp_gt_un (double a, double b)
 {
 	return isunordered (a, b) || a > b;
 }
 
-gboolean
+gboolean MONO_JIT_ICALL_FP_ABI
 mono_fcmp_le_un (double a, double b)
 {
 	return isunordered (a, b) || a <= b;
 }
 
-gboolean
+gboolean MONO_JIT_ICALL_FP_ABI
 mono_fcmp_lt_un (double a, double b)
 {
 	return isunordered (a, b) || a < b;
 }
 
-gboolean
+gboolean MONO_JIT_ICALL_FP_ABI
 mono_fceq (double a, double b)
 {
 	return a == b;
 }
 
-gboolean
+gboolean MONO_JIT_ICALL_FP_ABI
 mono_fcgt (double a, double b)
 {
 	return a > b;
 }
 
-gboolean
+gboolean MONO_JIT_ICALL_FP_ABI
 mono_fcgt_un (double a, double b)
 {
 	return isunordered (a, b) || a > b;
 }
 
-gboolean
+gboolean MONO_JIT_ICALL_FP_ABI
 mono_fclt (double a, double b)
 {
 	return a < b;
 }
 
-gboolean
+gboolean MONO_JIT_ICALL_FP_ABI
 mono_fclt_un (double a, double b)
 {
 	return isunordered (a, b) || a < b;
 }
 
-gboolean
+gboolean MONO_JIT_ICALL_FP_ABI
 mono_isfinite (double a)
 {
 #ifdef HAVE_ISFINITE
@@ -610,20 +618,20 @@ mono_isfinite (double a)
 #endif
 }
 
-double
+double MONO_JIT_ICALL_FP_ABI
 mono_fload_r4 (float *ptr)
 {
 	return *ptr;
 }
 
-void
+void MONO_JIT_ICALL_FP_ABI
 mono_fstore_r4 (double val, float *ptr)
 {
 	*ptr = (float)val;
 }
 
 /* returns the integer bitpattern that is passed in the regs or stack */
-guint32
+guint32 MONO_JIT_ICALL_FP_ABI
 mono_fload_r4_arg (double val)
 {
 	float v = (float)val;
@@ -817,14 +825,14 @@ mono_ldtoken_wrapper_generic_shared (MonoImage *image, int token, MonoMethod *me
 	return mono_ldtoken_wrapper (image, token, generic_context);
 }
 
-guint64
+guint64 MONO_JIT_ICALL_FP_ABI
 mono_fconv_u8 (double v)
 {
 	return (guint64)v;
 }
 
 #ifdef MONO_ARCH_EMULATE_FCONV_TO_I8
-gint64
+gint64 MONO_JIT_ICALL_FP_ABI
 mono_fconv_i8 (double v)
 {
 	/* no need, no exceptions: MONO_ARCH_SAVE_REGS;*/
@@ -832,7 +840,7 @@ mono_fconv_i8 (double v)
 }
 #endif
 
-guint32
+guint32 MONO_JIT_ICALL_FP_ABI
 mono_fconv_u4 (double v)
 {
 	/* no need, no exceptions: MONO_ARCH_SAVE_REGS;*/
@@ -850,7 +858,7 @@ extern long double aintl (long double);
 #endif
 #endif /* HAVE_TRUNC */
 
-gint64
+gint64 MONO_JIT_ICALL_FP_ABI
 mono_fconv_ovf_i8 (double v)
 {
 	gint64 res;
@@ -865,7 +873,7 @@ mono_fconv_ovf_i8 (double v)
 	return res;
 }
 
-guint64
+guint64 MONO_JIT_ICALL_FP_ABI
 mono_fconv_ovf_u8 (double v)
 {
 	guint64 res;
@@ -895,7 +903,7 @@ mono_fconv_ovf_u8 (double v)
 }
 
 #ifdef MONO_ARCH_EMULATE_LCONV_TO_R8
-double
+double MONO_JIT_ICALL_FP_ABI
 mono_lconv_to_r8 (gint64 a)
 {
 	return (double)a;
@@ -903,7 +911,11 @@ mono_lconv_to_r8 (gint64 a)
 #endif
 
 #ifdef MONO_ARCH_EMULATE_LCONV_TO_R4
-float
+#ifdef MONO_ARCH_SOFT_FLOAT
+double MONO_JIT_ICALL_FP_ABI
+#else
+float MONO_JIT_ICALL_FP_ABI
+#endif
 mono_lconv_to_r4 (gint64 a)
 {
 	return (float)a;
@@ -911,7 +923,7 @@ mono_lconv_to_r4 (gint64 a)
 #endif
 
 #ifdef MONO_ARCH_EMULATE_CONV_R8_UN
-double
+double MONO_JIT_ICALL_FP_ABI
 mono_conv_to_r8_un (guint32 a)
 {
 	return (double)a;
@@ -919,7 +931,7 @@ mono_conv_to_r8_un (guint32 a)
 #endif
 
 #ifdef MONO_ARCH_EMULATE_LCONV_TO_R8_UN
-double
+double MONO_JIT_ICALL_FP_ABI
 mono_lconv_to_r8_un (guint64 a)
 {
 	return (double)a;

--- a/mono/mini/jit-icalls.h
+++ b/mono/mini/jit-icalls.h
@@ -5,6 +5,20 @@
 
 #include "mini.h"
 
+/*
+ * ARM EABI code generation in this backend uses Mono's soft-float managed
+ * ABI for helper calls: floating-point helper arguments/results are passed in
+ * core registers.  armhf C code uses the VFP procedure-call standard by
+ * default.  Annotate only JIT helper entry points that expose float/double so
+ * those C functions match the calls this backend emits, without changing
+ * ordinary runtime C calls.
+ */
+#if defined(__arm__) && defined(__GNUC__) && defined(__ARM_PCS_VFP)
+#define MONO_JIT_ICALL_FP_ABI __attribute__((pcs("aapcs")))
+#else
+#define MONO_JIT_ICALL_FP_ABI
+#endif
+
 void* mono_ldftn (MonoMethod *method) MONO_INTERNAL;
 
 void* mono_ldvirtfn (MonoObject *obj, MonoMethod *method) MONO_INTERNAL;
@@ -33,7 +47,7 @@ gint32 mono_imul_ovf (gint32 a, gint32 b) MONO_INTERNAL;
 
 gint32 mono_imul_ovf_un (guint32 a, guint32 b) MONO_INTERNAL;
 
-double mono_fdiv (double a, double b) MONO_INTERNAL;
+double MONO_JIT_ICALL_FP_ABI mono_fdiv (double a, double b) MONO_INTERNAL;
 
 gint64 mono_lldiv (gint64 a, gint64 b) MONO_INTERNAL;
 
@@ -63,27 +77,31 @@ gpointer mono_ldtoken_wrapper (MonoImage *image, int token, MonoGenericContext *
 
 gpointer mono_ldtoken_wrapper_generic_shared (MonoImage *image, int token, MonoMethod *method) MONO_INTERNAL;
 
-guint64 mono_fconv_u8 (double v) MONO_INTERNAL;
+guint64 MONO_JIT_ICALL_FP_ABI mono_fconv_u8 (double v) MONO_INTERNAL;
 
-gint64 mono_fconv_i8 (double v) MONO_INTERNAL;
+gint64 MONO_JIT_ICALL_FP_ABI mono_fconv_i8 (double v) MONO_INTERNAL;
 
-guint32 mono_fconv_u4 (double v) MONO_INTERNAL;
+guint32 MONO_JIT_ICALL_FP_ABI mono_fconv_u4 (double v) MONO_INTERNAL;
 
-gint64 mono_fconv_ovf_i8 (double v) MONO_INTERNAL;
+gint64 MONO_JIT_ICALL_FP_ABI mono_fconv_ovf_i8 (double v) MONO_INTERNAL;
 
-guint64 mono_fconv_ovf_u8 (double v) MONO_INTERNAL;
+guint64 MONO_JIT_ICALL_FP_ABI mono_fconv_ovf_u8 (double v) MONO_INTERNAL;
 
-double mono_lconv_to_r8 (gint64 a) MONO_INTERNAL;
+double MONO_JIT_ICALL_FP_ABI mono_lconv_to_r8 (gint64 a) MONO_INTERNAL;
 
-double mono_conv_to_r8 (gint32 a) MONO_INTERNAL;
+double MONO_JIT_ICALL_FP_ABI mono_conv_to_r8 (gint32 a) MONO_INTERNAL;
 
-double mono_conv_to_r4 (gint32 a) MONO_INTERNAL;
+double MONO_JIT_ICALL_FP_ABI mono_conv_to_r4 (gint32 a) MONO_INTERNAL;
 
-float mono_lconv_to_r4 (gint64 a) MONO_INTERNAL;
+#ifdef MONO_ARCH_SOFT_FLOAT
+double MONO_JIT_ICALL_FP_ABI mono_lconv_to_r4 (gint64 a) MONO_INTERNAL;
+#else
+float MONO_JIT_ICALL_FP_ABI mono_lconv_to_r4 (gint64 a) MONO_INTERNAL;
+#endif
 
-double mono_conv_to_r8_un (guint32 a) MONO_INTERNAL;
+double MONO_JIT_ICALL_FP_ABI mono_conv_to_r8_un (guint32 a) MONO_INTERNAL;
 
-double mono_lconv_to_r8_un (guint64 a) MONO_INTERNAL;
+double MONO_JIT_ICALL_FP_ABI mono_lconv_to_r8_un (guint64 a) MONO_INTERNAL;
 
 gpointer mono_helper_compile_generic_method (MonoObject *obj, MonoMethod *method, gpointer *this_arg) MONO_INTERNAL;
 
@@ -93,63 +111,67 @@ MonoString *mono_helper_ldstr_mscorlib (guint32 idx) MONO_INTERNAL;
 
 MonoObject *mono_helper_newobj_mscorlib (guint32 idx) MONO_INTERNAL;
 
-double mono_fsub (double a, double b) MONO_INTERNAL;
+double MONO_JIT_ICALL_FP_ABI mono_fsub (double a, double b) MONO_INTERNAL;
 
-double mono_fadd (double a, double b) MONO_INTERNAL;
+double MONO_JIT_ICALL_FP_ABI mono_fadd (double a, double b) MONO_INTERNAL;
 
-double mono_fmul (double a, double b) MONO_INTERNAL;
+double MONO_JIT_ICALL_FP_ABI mono_fmul (double a, double b) MONO_INTERNAL;
 
-double mono_fneg (double a) MONO_INTERNAL;
+double MONO_JIT_ICALL_FP_ABI mono_fneg (double a) MONO_INTERNAL;
 
-double mono_fconv_r4 (double a) MONO_INTERNAL;
+double MONO_JIT_ICALL_FP_ABI mono_fconv_r4 (double a) MONO_INTERNAL;
 
-gint8 mono_fconv_i1 (double a) MONO_INTERNAL;
+gint8 MONO_JIT_ICALL_FP_ABI mono_fconv_i1 (double a) MONO_INTERNAL;
 
-gint16 mono_fconv_i2 (double a) MONO_INTERNAL;
+gint16 MONO_JIT_ICALL_FP_ABI mono_fconv_i2 (double a) MONO_INTERNAL;
 
-gint32 mono_fconv_i4 (double a) MONO_INTERNAL;
+gint32 MONO_JIT_ICALL_FP_ABI mono_fconv_i4 (double a) MONO_INTERNAL;
 
-guint8 mono_fconv_u1 (double a) MONO_INTERNAL;
+guint8 MONO_JIT_ICALL_FP_ABI mono_fconv_u1 (double a) MONO_INTERNAL;
 
-guint16 mono_fconv_u2 (double a) MONO_INTERNAL;
+guint16 MONO_JIT_ICALL_FP_ABI mono_fconv_u2 (double a) MONO_INTERNAL;
 
-gboolean mono_fcmp_eq (double a, double b) MONO_INTERNAL;
+gboolean MONO_JIT_ICALL_FP_ABI mono_fcmp_eq (double a, double b) MONO_INTERNAL;
 
-gboolean mono_fcmp_ge (double a, double b) MONO_INTERNAL;
+gboolean MONO_JIT_ICALL_FP_ABI mono_fcmp_ge (double a, double b) MONO_INTERNAL;
 
-gboolean mono_fcmp_gt (double a, double b) MONO_INTERNAL;
+gboolean MONO_JIT_ICALL_FP_ABI mono_fcmp_gt (double a, double b) MONO_INTERNAL;
 
-gboolean mono_fcmp_le (double a, double b) MONO_INTERNAL;
+gboolean MONO_JIT_ICALL_FP_ABI mono_fcmp_le (double a, double b) MONO_INTERNAL;
 
-gboolean mono_fcmp_lt (double a, double b) MONO_INTERNAL;
+gboolean MONO_JIT_ICALL_FP_ABI mono_fcmp_lt (double a, double b) MONO_INTERNAL;
 
-gboolean mono_fcmp_ne_un (double a, double b) MONO_INTERNAL;
+gboolean MONO_JIT_ICALL_FP_ABI mono_fcmp_ne_un (double a, double b) MONO_INTERNAL;
 
-gboolean mono_fcmp_ge_un (double a, double b) MONO_INTERNAL;
+gboolean MONO_JIT_ICALL_FP_ABI mono_fcmp_ge_un (double a, double b) MONO_INTERNAL;
 
-gboolean mono_fcmp_gt_un (double a, double b) MONO_INTERNAL;
+gboolean MONO_JIT_ICALL_FP_ABI mono_fcmp_gt_un (double a, double b) MONO_INTERNAL;
 
-gboolean mono_fcmp_le_un (double a, double b) MONO_INTERNAL;
+gboolean MONO_JIT_ICALL_FP_ABI mono_fcmp_le_un (double a, double b) MONO_INTERNAL;
 
-gboolean mono_fcmp_lt_un (double a, double b) MONO_INTERNAL;
+gboolean MONO_JIT_ICALL_FP_ABI mono_fcmp_lt_un (double a, double b) MONO_INTERNAL;
 
-gboolean mono_fceq (double a, double b) MONO_INTERNAL;
+gboolean MONO_JIT_ICALL_FP_ABI mono_fceq (double a, double b) MONO_INTERNAL;
 
-gboolean mono_fcgt (double a, double b) MONO_INTERNAL;
+gboolean MONO_JIT_ICALL_FP_ABI mono_fcgt (double a, double b) MONO_INTERNAL;
 
-gboolean mono_fcgt_un (double a, double b) MONO_INTERNAL;
+gboolean MONO_JIT_ICALL_FP_ABI mono_fcgt_un (double a, double b) MONO_INTERNAL;
 
-gboolean mono_fclt (double a, double b) MONO_INTERNAL;
+gboolean MONO_JIT_ICALL_FP_ABI mono_fclt (double a, double b) MONO_INTERNAL;
 
-gboolean mono_fclt_un (double a, double b) MONO_INTERNAL;
+gboolean MONO_JIT_ICALL_FP_ABI mono_fclt_un (double a, double b) MONO_INTERNAL;
 
-gboolean mono_isfinite (double a) MONO_INTERNAL;
+gboolean MONO_JIT_ICALL_FP_ABI mono_isfinite (double a) MONO_INTERNAL;
 
-double   mono_fload_r4 (float *ptr) MONO_INTERNAL;
+double   MONO_JIT_ICALL_FP_ABI mono_fload_r4 (float *ptr) MONO_INTERNAL;
 
-void     mono_fstore_r4 (double val, float *ptr) MONO_INTERNAL;
+void     MONO_JIT_ICALL_FP_ABI mono_fstore_r4 (double val, float *ptr) MONO_INTERNAL;
 
-guint32  mono_fload_r4_arg (double val) MONO_INTERNAL;
+guint32  MONO_JIT_ICALL_FP_ABI mono_fload_r4_arg (double val) MONO_INTERNAL;
+
+#if defined(__arm__) && defined(__ARM_PCS_VFP)
+double MONO_JIT_ICALL_FP_ABI mono_frem (double a, double b) MONO_INTERNAL;
+#endif
 
 void     mono_break (void) MONO_INTERNAL;
 

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -5348,13 +5348,26 @@ mini_init (const char *filename, const char *runtime_version)
 	mono_register_opcode_emulation (OP_LCONV_TO_R8, "__emul_lconv_to_r8", "double long", mono_lconv_to_r8, FALSE);
 #endif
 #ifdef MONO_ARCH_EMULATE_LCONV_TO_R4
+	#ifdef MONO_ARCH_SOFT_FLOAT
+	/*
+	 * Soft-float ARM represents the managed F value in core registers using
+	 * the same "double" helper ABI as the rest of this backend.  The helper
+	 * still rounds through float; the signature describes the transport ABI.
+	 */
+	mono_register_opcode_emulation (OP_LCONV_TO_R4, "__emul_lconv_to_r4", "double long", mono_lconv_to_r4, FALSE);
+#else
 	mono_register_opcode_emulation (OP_LCONV_TO_R4, "__emul_lconv_to_r4", "float long", mono_lconv_to_r4, FALSE);
+#endif
 #endif
 #ifdef MONO_ARCH_EMULATE_LCONV_TO_R8_UN
 	mono_register_opcode_emulation (OP_LCONV_TO_R_UN, "__emul_lconv_to_r8_un", "double long", mono_lconv_to_r8_un, FALSE);
 #endif
 #ifdef MONO_ARCH_EMULATE_FREM
+	#if defined(__arm__) && defined(__ARM_PCS_VFP)
+	mono_register_opcode_emulation (OP_FREM, "__emul_frem", "double double double", mono_frem, FALSE);
+#else
 	mono_register_opcode_emulation (OP_FREM, "__emul_frem", "double double double", fmod, FALSE);
+#endif
 #endif
 
 #ifdef MONO_ARCH_SOFT_FLOAT

--- a/mono/utils/mono-compiler.h
+++ b/mono/utils/mono-compiler.h
@@ -131,6 +131,18 @@
 
 #endif
 
+/*
+ * Some old ARM backends deliberately use the base AAPCS for generated helper
+ * calls even when the C compiler targets armhf/VFP PCS.  Runtime entry points
+ * annotated with this macro must match those generated calls; unannotated C
+ * functions continue to use the platform ABI.
+ */
+#if defined(__arm__) && defined(__GNUC__) && defined(__ARM_PCS_VFP)
+#define MONO_ICALL_FP_ABI __attribute__((pcs("aapcs")))
+#else
+#define MONO_ICALL_FP_ABI
+#endif
+
 /* Deal with Microsoft C compiler differences */
 #ifdef _MSC_VER
 


### PR DESCRIPTION
This PR allows mono 2.6.4 to be built using armhf ABI (as well as older arm ABIs and also non-arm).

Mono 2.6.4 has VFP instruction-selection support, but its ARM call lowering is not an ARM hard-float procedure-call ABI implementation: `ARM_NUM_REG_FPARGS` is zero, `float`/`double` arguments are assigned through the core-register/stack AAPCS (ARM EABI) path, and floating returns are moved through r0/r1.  Therefore selecting `ARM_FPU_VFP` is not sufficient to make generated helper, `icall`, P/Invoke, or `calli` boundaries agree with armhf C code.

The generated ARM helper ABI used by this backend passes floating-point helper arguments/results in core registers.  On armhf, ordinary C functions are compiled with the VFP procedure-call standard, so unannotated native functions with `float`/`double` arguments or results use VFP registers instead.  That makes managed/JIT callers and native C callees disagree about where the values are.

Mark only JIT helper and metadata icall entry points whose native signatures expose `float` or `double` with `pcs("aapcs")` on ARM hard-float.  Ordinary runtime C calls keep the system ABI.  `lconv.r4` remains numerically rounded through `float`, but its registered helper signature describes the `double` transport ABI used by Mono's soft-float ARM helper calls.  `frem` uses an annotated helper instead of registering hard-float `libc` `fmod` directly.