### PR TITLE
Mono 1.2.6 ARM runtime/JIT correctness fixes.

### DIFF
--- a/mono/mini/exceptions-arm.c
+++ b/mono/mini/exceptions-arm.c
@@ -106,6 +106,11 @@ typedef struct my_ucontext {
 /* nothing to do */
 #define setup_context(ctx)
 
+#define ARM_RESTORE_CONTEXT_SIZE 128
+#define ARM_CALL_FILTER_SIZE 320
+#define ARM_THROW_EXCEPTION_SIZE 132
+#define ARM_THROW_EXCEPTION_BY_NAME_SIZE 168
+
 /*
  * arch_get_restore_context:
  *
@@ -116,13 +121,21 @@ gpointer
 mono_arch_get_restore_context (void)
 {
 	guint8 *code;
-	static guint8 start [128];
+	static guint8 *start = NULL;
 	static int inited = 0;
 
 	if (inited)
 		return start;
-	inited = 1;
 
+	/*
+	 * This buffer contains generated ARM instructions.  Keeping it in a
+	 * static array puts executable code in .bss; on armhf systems with
+	 * non-executable data mappings, exception dispatch then jumps into a
+	 * data page and faults.  Use Mono's global code manager, like the ARM
+	 * trampolines and other exception backends, so the helper has the same
+	 * executable-code properties as JIT output.
+	 */
+	start = mono_global_codeman_reserve (ARM_RESTORE_CONTEXT_SIZE);
 	code = start;
 	restore_regs_from_context (ARMREG_R0, ARMREG_R1, ARMREG_R2);
 	/* restore also the stack pointer, FIXME: handle sp != fp */
@@ -132,8 +145,9 @@ mono_arch_get_restore_context (void)
 	/* never reached */
 	ARM_DBRK (code);
 
-	g_assert ((code - start) < sizeof(start));
+	g_assert ((code - start) < ARM_RESTORE_CONTEXT_SIZE);
 	mono_arch_flush_icache (start, code - start);
+	inited = 1;
 	return start;
 }
 
@@ -147,7 +161,7 @@ mono_arch_get_restore_context (void)
 gpointer
 mono_arch_get_call_filter (void)
 {
-	static guint8 start [320];
+	static guint8 *start = NULL;
 	static int inited = 0;
 	guint8 *code;
 	int alloc_size, pos, i;
@@ -155,7 +169,11 @@ mono_arch_get_call_filter (void)
 	if (inited)
 		return start;
 
-	inited = 1;
+	/*
+	 * The filter/finally entry helper is generated code too.  It must not
+	 * rely on writable static storage being executable.
+	 */
+	start = mono_global_codeman_reserve (ARM_CALL_FILTER_SIZE);
 	/* call_filter (MonoContext *ctx, unsigned long eip, gpointer exc) */
 	code = start;
 
@@ -173,8 +191,9 @@ mono_arch_get_call_filter (void)
 	/* epilog */
 	ARM_POP_NWB (code, 0xff0 | ((1 << ARMREG_SP) | (1 << ARMREG_PC)));
 
-	g_assert ((code - start) < sizeof(start));
+	g_assert ((code - start) < ARM_CALL_FILTER_SIZE);
 	mono_arch_flush_icache (start, code - start);
+	inited = 1;
 	return start;
 }
 
@@ -278,12 +297,17 @@ mono_arch_get_throw_exception_generic (guint8 *start, int size, int by_name, gbo
 gpointer
 mono_arch_get_rethrow_exception (void)
 {
-	static guint8 start [132];
+	static guint8 *start = NULL;
 	static int inited = 0;
 
 	if (inited)
 		return start;
-	mono_arch_get_throw_exception_generic (start, sizeof (start), FALSE, TRUE);
+	/*
+	 * Generated throw helpers are entered as code during managed exception
+	 * dispatch.  Allocate them as executable code rather than .bss data.
+	 */
+	start = mono_global_codeman_reserve (ARM_THROW_EXCEPTION_SIZE);
+	mono_arch_get_throw_exception_generic (start, ARM_THROW_EXCEPTION_SIZE, FALSE, TRUE);
 	inited = 1;
 	return start;
 }
@@ -302,12 +326,17 @@ mono_arch_get_rethrow_exception (void)
 gpointer 
 mono_arch_get_throw_exception (void)
 {
-	static guint8 start [132];
+	static guint8 *start = NULL;
 	static int inited = 0;
 
 	if (inited)
 		return start;
-	mono_arch_get_throw_exception_generic (start, sizeof (start), FALSE, FALSE);
+	/*
+	 * This helper is generated executable code.  Static writable storage is
+	 * not an executable-code allocation contract on armhf.
+	 */
+	start = mono_global_codeman_reserve (ARM_THROW_EXCEPTION_SIZE);
+	mono_arch_get_throw_exception_generic (start, ARM_THROW_EXCEPTION_SIZE, FALSE, FALSE);
 	inited = 1;
 	return start;
 }
@@ -327,12 +356,17 @@ mono_arch_get_throw_exception (void)
 gpointer 
 mono_arch_get_throw_exception_by_name (void)
 {
-	static guint8 start [168];
+	static guint8 *start = NULL;
 	static int inited = 0;
 
 	if (inited)
 		return start;
-	mono_arch_get_throw_exception_generic (start, sizeof (start), TRUE, FALSE);
+	/*
+	 * By-name exception creation uses the same generated-code helper path;
+	 * keep it in executable code memory for the same reason.
+	 */
+	start = mono_global_codeman_reserve (ARM_THROW_EXCEPTION_BY_NAME_SIZE);
+	mono_arch_get_throw_exception_generic (start, ARM_THROW_EXCEPTION_BY_NAME_SIZE, TRUE, FALSE);
 	inited = 1;
 	return start;
 }	
@@ -520,4 +554,3 @@ mono_arch_has_unwind_info (gconstpointer addr)
 {
 	return FALSE;
 }
-

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -600,10 +600,30 @@ add_general (guint *gr, guint *stack_size, ArgInfo *ainfo, gboolean simple)
 			ainfo->reg = *gr;
 		}
 	} else {
-		if (*gr == ARMREG_R3
 #ifdef __ARM_EABI__
-				&& 0
-#endif
+		/*
+		 * AAPCS requires 64-bit core-register arguments to start in an
+		 * even-numbered argument register.  If the next register is r3,
+		 * aligning would skip to r4, but r4 is callee-saved, not an
+		 * argument register.  The whole 64-bit argument must therefore be
+		 * passed on the stack.  Recording r4 here corrupts managed calls
+		 * such as ILGenerator.Emit(OpCode, double), where a preceding
+		 * value-type argument leaves gr == r3 before the double argument.
+		 */
+		if ((*gr) & 1)
+			(*gr) ++;
+		if (*gr > ARMREG_R3) {
+			*stack_size += 7;
+			*stack_size &= ~7;
+			ainfo->offset = *stack_size;
+			ainfo->reg = ARMREG_SP; /* in the caller */
+			ainfo->regtype = RegTypeBase;
+			*stack_size += 8;
+		} else {
+			ainfo->reg = *gr;
+		}
+#else
+		if (*gr == ARMREG_R3
 					) {
 			/* first word in r3 and the second on the stack */
 			ainfo->offset = *stack_size;
@@ -620,12 +640,9 @@ add_general (guint *gr, guint *stack_size, ArgInfo *ainfo, gboolean simple)
 			ainfo->regtype = RegTypeBase;
 			*stack_size += 8;
 		} else {
-#ifdef __ARM_EABI__
-			if ((*gr) & 1)
-				(*gr) ++;
-#endif
 			ainfo->reg = *gr;
 		}
+#endif
 		(*gr) ++;
 	}
 	(*gr) ++;


### PR DESCRIPTION
Repair incorrect ARM calling convention and generated-code placement invariants.

ARM EABI requires 64-bit core-register arguments to start in an even-numbered argument register.  If the next register is r3, there is no r4 argument register, so the whole 64-bit argument must be passed on the stack.  The old argument placement aligned r3 to r4 and recorded the argument as register-passed, corrupting calls such as ILGenerator.Emit(OpCode, double).

ARM exception helper stubs were emitted into static byte arrays in .bss and then called as code.  On systems with non-executable data mappings this faults at the first managed exception dispatch.  Allocate these generated instruction buffers from Mono's executable code manager.