### PR TITLE
Mono 2.11.4 Force the old ARM JIT backend to use no VFP register ABI

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -2751,22 +2751,23 @@ if test ${TARGET} = ARM && test x$cross_compiling = xno && test x$enable_mcs_bui
 
 	fpu=NONE
 	if gcc -v 2>&1 | grep -q -- '--with-float=hard'; then
-	   fpu=VFP_HARD
-	fi
-
-	if test x$fpu = xNONE; then
+	   # Hard-float ABI is not supported by the backend yet.
+	   # Force NONE and skip FPA (legacy) checks.
+	   fpu=NONE
+	else
 	   ORIG_CFLAGS=$CFLAGS
 	   CFLAGS="$CFLAGS -mfpu=vfp -mfloat-abi=softfp"
 	   AC_TRY_RUN([
 				int main () { __asm__ ("faddd	d7, d6, d7"); return 0; }
 				], fpu=VFP, fpu=NONE)
 	   CFLAGS=$ORIG_CFLAGS
-	fi
 
-	if test x$fpu = xNONE; then
+
+	   if test x$fpu = xNONE; then
 		AC_TRY_COMPILE([], [
 			__asm__ ("ldfd f0, [r0]");
 			], fpu=FPA, fpu=NONE)
+	   fi
 	fi
 
 	AC_MSG_RESULT($fpu)


### PR DESCRIPTION
Mono's configure script can detect a hard-float ARM toolchain and select ARM_FPU_VFP_HARD.  That is not a usable configuration for this backend: mono/mini/mini-arm.h explicitly rejects it with

  #error "hardfp-abi not yet supported."

The backend also keeps ARM_NUM_REG_FPARGS at zero for the non-iPhone ABI, so it does not implement the ARM hard-float procedure-call convention for managed or helper calls.  Letting configure select VFP or VFP_HARD therefore creates a mixed model: C code is built for the platform ABI, while the old ARM JIT still expects floating-point values to cross its helper boundary using the non-VFP integer/core-register ABI.

Force configure's ARM FPU choice to NONE.  This does not ask GCC to build the whole runtime with soft-float; it only keeps Mono's old ARM backend in the non-VFP code-generation mode that it actually implements.