### PR TITLE
Mono 3.0.12 Force the old ARM JIT backend to use no VFP register ABI

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -3014,23 +3014,19 @@ if test ${TARGET} = ARM; then
 			#endif
 			return 0;
 		], [
-			fpu=VFP_HARD
-		], [
 			fpu=NONE
-		])
-	fi
-
-	# No 'hard' ABI. 'soft' or 'softfp'?
-	if test x$fpu = xNONE; then
-		AC_TRY_COMPILE([], [
-			#ifdef __SOFTFP__
-			#error "Float ABI is not 'softfp'"
-			#endif
-			return 0;
 		], [
-			fpu=VFP
-		], [
-			fpu=NONE
+			# No 'hard' ABI. 'soft' or 'softfp'?
+			AC_TRY_COMPILE([], [
+				#ifdef __SOFTFP__
+				#error "Float ABI is not 'softfp'"
+				#endif
+				return 0;
+			], [
+				fpu=VFP
+			], [
+				fpu=NONE
+			])
 		])
 	fi
 


### PR DESCRIPTION
Mono's configure script detects the ARM floating-point ABI from the compiler predefines.  On armhf, __ARM_PCS_VFP is defined, so configure selects ARM_FPU_VFP_HARD.  That is not a usable configuration for this backend: mono/mini/mini-arm.h explicitly rejects it with

  #error "hardfp-abi not yet supported."

The backend also keeps ARM_NUM_REG_FPARGS at zero for the non-iPhone ABI, so it does not implement the ARM hard-float procedure-call convention for managed or helper calls.  Letting configure select VFP_HARD therefore creates a mixed model: C code is built for the platform ABI, while the old ARM JIT still expects floating-point values to cross its helper boundary using the non-VFP integer/core-register ABI.

Force configure's ARM FPU choice to NONE for non-Darwin ARM.  This does not ask GCC to build the whole runtime with soft-float; it only keeps Mono's old ARM backend in the non-VFP code-generation mode that it actually implements.