### PR TITLE
Mono 1.2.6 ARM EABI floating-point ABI fixes.

### DIFF
--- a/mono/metadata/decimal.c
+++ b/mono/metadata/decimal.c
@@ -872,7 +872,7 @@ DECINLINE static int calcDigits(guint64 alo, guint64 ahi)
     return tlog10+1;
 }
 
-gint32 mono_double2decimal(/*[Out]*/decimal_repr* pA, double val, gint32 digits)
+gint32 MONO_ICALL_FP_ABI mono_double2decimal(/*[Out]*/decimal_repr* pA, double val, gint32 digits)
 {
     guint64 alo, ahi;
     guint64* p = (guint64*)(&val);
@@ -1481,7 +1481,7 @@ DECINLINE static void buildIEEE754Double(double* pd, int sign, int texp, guint64
 #endif
 }
 
-double mono_decimal2double(/*[In]*/decimal_repr* pA)
+double MONO_ICALL_FP_ABI mono_decimal2double(/*[In]*/decimal_repr* pA)
 {
     double d;
     guint64 alo, ahi, mantisse;
@@ -1571,4 +1571,3 @@ gint32 mono_decimalSetExponent(/*[In, Out]*/decimal_repr* pA, gint32 texp)
 }
 
 #endif /* DISABLE_DECIMAL */
-

--- a/mono/metadata/decimal.h
+++ b/mono/metadata/decimal.h
@@ -2,6 +2,7 @@
 #include "mono/utils/mono-compiler.h"
 
 /* representation for C# type decimal */
+
 /* This is the layout of MSC */
 typedef struct
 {
@@ -31,7 +32,7 @@ typedef struct
 
 /* function prototypes */
 gint32 mono_decimalIncr(/*[In, Out]*/decimal_repr* pA, /*[In]*/decimal_repr* pB) MONO_INTERNAL;
-gint32 mono_double2decimal(/*[Out]*/decimal_repr* pA, double val, gint32 digits) MONO_INTERNAL;
+gint32 MONO_ICALL_FP_ABI mono_double2decimal(/*[Out]*/decimal_repr* pA, double val, gint32 digits) MONO_INTERNAL;
 gint32 mono_decimal2UInt64(/*[In]*/decimal_repr* pD, guint64* pResult) MONO_INTERNAL;
 gint32 mono_decimal2Int64(/*[In]*/decimal_repr* pD, gint64* pResult) MONO_INTERNAL;
 void mono_decimalFloorAndTrunc(/*[In, Out]*/decimal_repr* pD, gint32 floorFlag) MONO_INTERNAL;
@@ -40,10 +41,9 @@ gint32 mono_decimalMult(/*[In, Out]*/decimal_repr* pA, /*[In]*/decimal_repr* pB)
 gint32 mono_decimalDiv(/*[Out]*/decimal_repr* pC, /*[In]*/decimal_repr* pA, /*[In]*/decimal_repr* pB) MONO_INTERNAL;
 gint32 mono_decimalIntDiv(/*[Out]*/decimal_repr* pC, /*[In]*/decimal_repr* pA, /*[In]*/decimal_repr* pB) MONO_INTERNAL;
 gint32 mono_decimalCompare(/*[In]*/decimal_repr* pA, /*[In]*/decimal_repr* pB) MONO_INTERNAL;
-double mono_decimal2double(/*[In]*/decimal_repr* pA) MONO_INTERNAL;
+double MONO_ICALL_FP_ABI mono_decimal2double(/*[In]*/decimal_repr* pA) MONO_INTERNAL;
 gint32 mono_decimalSetExponent(/*[In, Out]*/decimal_repr* pA, gint32 texp) MONO_INTERNAL;
 
 gint32 mono_string2decimal(/*[Out]*/decimal_repr* pA, /*[In]*/MonoString* s, gint32 decrDecimal, gint32 sign) MONO_INTERNAL;
 gint32 mono_decimal2string(/*[In]*/decimal_repr* pA, int digits, int decimals,
 			 /*[Out]*/MonoArray* pArray, gint32 bufSize, gint32* pDecPos, gint32* pSign) MONO_INTERNAL;
-

--- a/mono/metadata/sysmath.c
+++ b/mono/metadata/sysmath.c
@@ -30,12 +30,12 @@ static __huge_val_t __huge_val = { __HUGE_VAL_bytes };
 #endif
 
 
-gdouble ves_icall_System_Math_Floor (gdouble x) {
+gdouble MONO_ICALL_FP_ABI ves_icall_System_Math_Floor (gdouble x) {
 	MONO_ARCH_SAVE_REGS;
 	return floor(x);
 }
 
-gdouble ves_icall_System_Math_Round (gdouble x) {
+gdouble MONO_ICALL_FP_ABI ves_icall_System_Math_Round (gdouble x) {
 	double int_part, dec_part;
 	MONO_ARCH_SAVE_REGS;
 	int_part = floor(x);
@@ -48,7 +48,7 @@ gdouble ves_icall_System_Math_Round (gdouble x) {
 	return int_part;
 }
 
-gdouble ves_icall_System_Math_Round2 (gdouble value, gint32 digits) {
+gdouble MONO_ICALL_FP_ABI ves_icall_System_Math_Round2 (gdouble value, gint32 digits) {
 	double p, int_part, dec_part;
 	MONO_ARCH_SAVE_REGS;
 	if (value == HUGE_VAL)
@@ -67,7 +67,7 @@ gdouble ves_icall_System_Math_Round2 (gdouble value, gint32 digits) {
 	return int_part + dec_part;
 }
 
-gdouble 
+gdouble MONO_ICALL_FP_ABI
 ves_icall_System_Math_Sin (gdouble x)
 {
 	MONO_ARCH_SAVE_REGS;
@@ -75,7 +75,7 @@ ves_icall_System_Math_Sin (gdouble x)
 	return sin (x);
 }
 
-gdouble 
+gdouble MONO_ICALL_FP_ABI
 ves_icall_System_Math_Cos (gdouble x)
 {
 	MONO_ARCH_SAVE_REGS;
@@ -83,7 +83,7 @@ ves_icall_System_Math_Cos (gdouble x)
 	return cos (x);
 }
 
-gdouble 
+gdouble MONO_ICALL_FP_ABI
 ves_icall_System_Math_Tan (gdouble x)
 {
 	MONO_ARCH_SAVE_REGS;
@@ -91,7 +91,7 @@ ves_icall_System_Math_Tan (gdouble x)
 	return tan (x);
 }
 
-gdouble 
+gdouble MONO_ICALL_FP_ABI
 ves_icall_System_Math_Sinh (gdouble x)
 {
 	MONO_ARCH_SAVE_REGS;
@@ -99,7 +99,7 @@ ves_icall_System_Math_Sinh (gdouble x)
 	return sinh (x);
 }
 
-gdouble 
+gdouble MONO_ICALL_FP_ABI
 ves_icall_System_Math_Cosh (gdouble x)
 {
 	MONO_ARCH_SAVE_REGS;
@@ -107,7 +107,7 @@ ves_icall_System_Math_Cosh (gdouble x)
 	return cosh (x);
 }
 
-gdouble 
+gdouble MONO_ICALL_FP_ABI
 ves_icall_System_Math_Tanh (gdouble x)
 {
 	MONO_ARCH_SAVE_REGS;
@@ -115,7 +115,7 @@ ves_icall_System_Math_Tanh (gdouble x)
 	return tanh (x);
 }
 
-gdouble 
+gdouble MONO_ICALL_FP_ABI
 ves_icall_System_Math_Acos (gdouble x)
 {
 	MONO_ARCH_SAVE_REGS;
@@ -126,7 +126,7 @@ ves_icall_System_Math_Acos (gdouble x)
 	return acos (x);
 }
 
-gdouble 
+gdouble MONO_ICALL_FP_ABI
 ves_icall_System_Math_Asin (gdouble x)
 {
 	MONO_ARCH_SAVE_REGS;
@@ -137,7 +137,7 @@ ves_icall_System_Math_Asin (gdouble x)
 	return asin (x);
 }
 
-gdouble 
+gdouble MONO_ICALL_FP_ABI
 ves_icall_System_Math_Atan (gdouble x)
 {
 	MONO_ARCH_SAVE_REGS;
@@ -145,7 +145,7 @@ ves_icall_System_Math_Atan (gdouble x)
 	return atan (x);
 }
 
-gdouble 
+gdouble MONO_ICALL_FP_ABI
 ves_icall_System_Math_Atan2 (gdouble y, gdouble x)
 {
 	double result;
@@ -161,7 +161,7 @@ ves_icall_System_Math_Atan2 (gdouble y, gdouble x)
 	return (result == -0)? 0: result;
 }
 
-gdouble 
+gdouble MONO_ICALL_FP_ABI
 ves_icall_System_Math_Exp (gdouble x)
 {
 	MONO_ARCH_SAVE_REGS;
@@ -169,7 +169,7 @@ ves_icall_System_Math_Exp (gdouble x)
 	return exp (x);
 }
 
-gdouble 
+gdouble MONO_ICALL_FP_ABI
 ves_icall_System_Math_Log (gdouble x)
 {
 	MONO_ARCH_SAVE_REGS;
@@ -182,7 +182,7 @@ ves_icall_System_Math_Log (gdouble x)
 	return log (x);
 }
 
-gdouble 
+gdouble MONO_ICALL_FP_ABI
 ves_icall_System_Math_Log10 (gdouble x)
 {
 	MONO_ARCH_SAVE_REGS;
@@ -195,7 +195,7 @@ ves_icall_System_Math_Log10 (gdouble x)
 	return log10 (x);
 }
 
-gdouble 
+gdouble MONO_ICALL_FP_ABI
 ves_icall_System_Math_Pow (gdouble x, gdouble y)
 {
 	double result;
@@ -231,7 +231,7 @@ ves_icall_System_Math_Pow (gdouble x, gdouble y)
 	return (result == -0)? 0: result;
 }
 
-gdouble 
+gdouble MONO_ICALL_FP_ABI
 ves_icall_System_Math_Sqrt (gdouble x)
 {
 	MONO_ARCH_SAVE_REGS;

--- a/mono/metadata/sysmath.h
+++ b/mono/metadata/sysmath.h
@@ -14,53 +14,53 @@
 #include <glib.h>
 #include "mono/utils/mono-compiler.h"
 
-extern gdouble ves_icall_System_Math_Floor (gdouble x) MONO_INTERNAL;
-extern gdouble ves_icall_System_Math_Round (gdouble x) MONO_INTERNAL;
-extern gdouble ves_icall_System_Math_Round2 (gdouble value, gint32 digits) MONO_INTERNAL;
+extern gdouble MONO_ICALL_FP_ABI ves_icall_System_Math_Floor (gdouble x) MONO_INTERNAL;
+extern gdouble MONO_ICALL_FP_ABI ves_icall_System_Math_Round (gdouble x) MONO_INTERNAL;
+extern gdouble MONO_ICALL_FP_ABI ves_icall_System_Math_Round2 (gdouble value, gint32 digits) MONO_INTERNAL;
 
-extern gdouble 
+extern gdouble MONO_ICALL_FP_ABI
 ves_icall_System_Math_Sin (gdouble x) MONO_INTERNAL;
 
-extern gdouble 
+extern gdouble MONO_ICALL_FP_ABI
 ves_icall_System_Math_Cos (gdouble x) MONO_INTERNAL;
 
-extern gdouble 
+extern gdouble MONO_ICALL_FP_ABI
 ves_icall_System_Math_Tan (gdouble x) MONO_INTERNAL;
 
-extern gdouble 
+extern gdouble MONO_ICALL_FP_ABI
 ves_icall_System_Math_Sinh (gdouble x) MONO_INTERNAL;
 
-extern gdouble 
+extern gdouble MONO_ICALL_FP_ABI
 ves_icall_System_Math_Cosh (gdouble x) MONO_INTERNAL;
 
-extern gdouble 
+extern gdouble MONO_ICALL_FP_ABI
 ves_icall_System_Math_Tanh (gdouble x) MONO_INTERNAL;
 
-extern gdouble 
+extern gdouble MONO_ICALL_FP_ABI
 ves_icall_System_Math_Acos (gdouble x) MONO_INTERNAL;
 
-extern gdouble 
+extern gdouble MONO_ICALL_FP_ABI
 ves_icall_System_Math_Asin (gdouble x) MONO_INTERNAL;
 
-extern gdouble 
+extern gdouble MONO_ICALL_FP_ABI
 ves_icall_System_Math_Atan (gdouble x) MONO_INTERNAL;
 
-extern gdouble 
+extern gdouble MONO_ICALL_FP_ABI
 ves_icall_System_Math_Atan2 (gdouble y, gdouble x) MONO_INTERNAL;
 
-extern gdouble 
+extern gdouble MONO_ICALL_FP_ABI
 ves_icall_System_Math_Exp (gdouble x) MONO_INTERNAL;
 
-extern gdouble 
+extern gdouble MONO_ICALL_FP_ABI
 ves_icall_System_Math_Log (gdouble x) MONO_INTERNAL;
 
-extern gdouble 
+extern gdouble MONO_ICALL_FP_ABI
 ves_icall_System_Math_Log10 (gdouble x) MONO_INTERNAL;
 
-extern gdouble 
+extern gdouble MONO_ICALL_FP_ABI
 ves_icall_System_Math_Pow (gdouble x, gdouble y) MONO_INTERNAL;
 
-extern gdouble 
+extern gdouble MONO_ICALL_FP_ABI
 ves_icall_System_Math_Sqrt (gdouble x) MONO_INTERNAL;
 
 #endif

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -84,14 +84,14 @@ extern gint64 ves_icall_System_Threading_Interlocked_Decrement_Long(gint64 * loc
 extern gint32 ves_icall_System_Threading_Interlocked_Exchange_Int(gint32 *location, gint32 value) MONO_INTERNAL;
 extern gint64 ves_icall_System_Threading_Interlocked_Exchange_Long(gint64 *location, gint64 value) MONO_INTERNAL;
 extern MonoObject *ves_icall_System_Threading_Interlocked_Exchange_Object(MonoObject **location, MonoObject *value) MONO_INTERNAL;
-extern gfloat ves_icall_System_Threading_Interlocked_Exchange_Single(gfloat *location, gfloat value) MONO_INTERNAL;
-extern gdouble ves_icall_System_Threading_Interlocked_Exchange_Double(gdouble *location, gdouble value) MONO_INTERNAL;
+extern gfloat MONO_ICALL_FP_ABI ves_icall_System_Threading_Interlocked_Exchange_Single(gfloat *location, gfloat value) MONO_INTERNAL;
+extern gdouble MONO_ICALL_FP_ABI ves_icall_System_Threading_Interlocked_Exchange_Double(gdouble *location, gdouble value) MONO_INTERNAL;
 
 extern gint32 ves_icall_System_Threading_Interlocked_CompareExchange_Int(gint32 *location, gint32 value, gint32 comparand) MONO_INTERNAL;
 extern gint64 ves_icall_System_Threading_Interlocked_CompareExchange_Long(gint64 *location, gint64 value, gint64 comparand) MONO_INTERNAL;
 extern MonoObject *ves_icall_System_Threading_Interlocked_CompareExchange_Object(MonoObject **location, MonoObject *value, MonoObject *comparand) MONO_INTERNAL;
-extern gfloat ves_icall_System_Threading_Interlocked_CompareExchange_Single(gfloat *location, gfloat value, gfloat comparand) MONO_INTERNAL;
-extern gdouble ves_icall_System_Threading_Interlocked_CompareExchange_Double(gdouble *location, gdouble value, gdouble comparand) MONO_INTERNAL;
+extern gfloat MONO_ICALL_FP_ABI ves_icall_System_Threading_Interlocked_CompareExchange_Single(gfloat *location, gfloat value, gfloat comparand) MONO_INTERNAL;
+extern gdouble MONO_ICALL_FP_ABI ves_icall_System_Threading_Interlocked_CompareExchange_Double(gdouble *location, gdouble value, gdouble comparand) MONO_INTERNAL;
 extern MonoObject* ves_icall_System_Threading_Interlocked_CompareExchange_T(MonoObject **location, MonoObject *value, MonoObject *comparand) MONO_INTERNAL;
 extern MonoObject* ves_icall_System_Threading_Interlocked_Exchange_T(MonoObject **location, MonoObject *value) MONO_INTERNAL;
 

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1587,7 +1587,7 @@ MonoObject * ves_icall_System_Threading_Interlocked_Exchange_Object (MonoObject 
 	return (MonoObject *) InterlockedExchangePointer((gpointer *) location, value);
 }
 
-gfloat ves_icall_System_Threading_Interlocked_Exchange_Single (gfloat *location, gfloat value)
+gfloat MONO_ICALL_FP_ABI ves_icall_System_Threading_Interlocked_Exchange_Single (gfloat *location, gfloat value)
 {
 	IntFloatUnion val, ret;
 
@@ -1620,7 +1620,7 @@ ves_icall_System_Threading_Interlocked_Exchange_Long (gint64 *location, gint64 v
 #endif
 }
 
-gdouble 
+gdouble MONO_ICALL_FP_ABI
 ves_icall_System_Threading_Interlocked_Exchange_Double (gdouble *location, gdouble value)
 {
 #if SIZEOF_VOID_P == 8
@@ -1660,7 +1660,7 @@ MonoObject * ves_icall_System_Threading_Interlocked_CompareExchange_Object (Mono
 	return (MonoObject *) InterlockedCompareExchangePointer((gpointer *) location, value, comparand);
 }
 
-gfloat ves_icall_System_Threading_Interlocked_CompareExchange_Single (gfloat *location, gfloat value, gfloat comparand)
+gfloat MONO_ICALL_FP_ABI ves_icall_System_Threading_Interlocked_CompareExchange_Single (gfloat *location, gfloat value, gfloat comparand)
 {
 	IntFloatUnion val, ret, cmp;
 
@@ -1673,7 +1673,7 @@ gfloat ves_icall_System_Threading_Interlocked_CompareExchange_Single (gfloat *lo
 	return ret.fval;
 }
 
-gdouble
+gdouble MONO_ICALL_FP_ABI
 ves_icall_System_Threading_Interlocked_CompareExchange_Double (gdouble *location, gdouble value, gdouble comparand)
 {
 #if SIZEOF_VOID_P == 8

--- a/mono/mini/jit-icalls.c
+++ b/mono/mini/jit-icalls.c
@@ -313,12 +313,20 @@ mono_imul_ovf_un (guint32 a, guint32 b)
 #endif
 
 #if defined(MONO_ARCH_EMULATE_MUL_DIV) || defined(MONO_ARCH_SOFT_FLOAT)
-double
+double MONO_JIT_ICALL_FP_ABI
 mono_fdiv (double a, double b)
 {
 	MONO_ARCH_SAVE_REGS;
 
 	return a / b;
+}
+#endif
+
+#if defined(__arm__) && defined(__ARM_PCS_VFP)
+double MONO_JIT_ICALL_FP_ABI
+mono_frem (double a, double b)
+{
+	return fmod (a, b);
 }
 #endif
 
@@ -421,182 +429,182 @@ mono_lshr (gint64 a, gint32 shamt)
 
 #ifdef MONO_ARCH_SOFT_FLOAT
 
-double
+double MONO_JIT_ICALL_FP_ABI
 mono_fsub (double a, double b)
 {
 	return a - b;
 }
 
-double
+double MONO_JIT_ICALL_FP_ABI
 mono_fadd (double a, double b)
 {
 	return a + b;
 }
 
-double
+double MONO_JIT_ICALL_FP_ABI
 mono_fmul (double a, double b)
 {
 	return a * b;
 }
 
-double
+double MONO_JIT_ICALL_FP_ABI
 mono_fneg (double a)
 {
 	return -a;
 }
 
-double
+double MONO_JIT_ICALL_FP_ABI
 mono_fconv_r4 (double a)
 {
 	return (float)a;
 }
 
-double
+double MONO_JIT_ICALL_FP_ABI
 mono_conv_to_r8 (int a)
 {
 	return (double)a;
 }
 
-double
+double MONO_JIT_ICALL_FP_ABI
 mono_conv_to_r4 (int a)
 {
 	return (double)(float)a;
 }
 
-gint8
+gint8 MONO_JIT_ICALL_FP_ABI
 mono_fconv_i1 (double a)
 {
 	return (gint8)a;
 }
 
-gint16
+gint16 MONO_JIT_ICALL_FP_ABI
 mono_fconv_i2 (double a)
 {
 	return (gint16)a;
 }
 
-gint32
+gint32 MONO_JIT_ICALL_FP_ABI
 mono_fconv_i4 (double a)
 {
 	return (gint32)a;
 }
 
-guint8
+guint8 MONO_JIT_ICALL_FP_ABI
 mono_fconv_u1 (double a)
 {
 	return (guint8)a;
 }
 
-guint16
+guint16 MONO_JIT_ICALL_FP_ABI
 mono_fconv_u2 (double a)
 {
 	return (guint16)a;
 }
 
-gboolean
+gboolean MONO_JIT_ICALL_FP_ABI
 mono_fcmp_eq (double a, double b)
 {
 	return a == b;
 }
 
-gboolean
+gboolean MONO_JIT_ICALL_FP_ABI
 mono_fcmp_ge (double a, double b)
 {
 	return a >= b;
 }
 
-gboolean
+gboolean MONO_JIT_ICALL_FP_ABI
 mono_fcmp_gt (double a, double b)
 {
 	return a > b;
 }
 
-gboolean
+gboolean MONO_JIT_ICALL_FP_ABI
 mono_fcmp_le (double a, double b)
 {
 	return a <= b;
 }
 
-gboolean
+gboolean MONO_JIT_ICALL_FP_ABI
 mono_fcmp_lt (double a, double b)
 {
 	return a < b;
 }
 
-gboolean
+gboolean MONO_JIT_ICALL_FP_ABI
 mono_fcmp_ne_un (double a, double b)
 {
 	return isunordered (a, b) || a != b;
 }
 
-gboolean
+gboolean MONO_JIT_ICALL_FP_ABI
 mono_fcmp_ge_un (double a, double b)
 {
 	return isunordered (a, b) || a >= b;
 }
 
-gboolean
+gboolean MONO_JIT_ICALL_FP_ABI
 mono_fcmp_gt_un (double a, double b)
 {
 	return isunordered (a, b) || a > b;
 }
 
-gboolean
+gboolean MONO_JIT_ICALL_FP_ABI
 mono_fcmp_le_un (double a, double b)
 {
 	return isunordered (a, b) || a <= b;
 }
 
-gboolean
+gboolean MONO_JIT_ICALL_FP_ABI
 mono_fcmp_lt_un (double a, double b)
 {
 	return isunordered (a, b) || a < b;
 }
 
-gboolean
+gboolean MONO_JIT_ICALL_FP_ABI
 mono_fceq (double a, double b)
 {
 	return a == b;
 }
 
-gboolean
+gboolean MONO_JIT_ICALL_FP_ABI
 mono_fcgt (double a, double b)
 {
 	return a > b;
 }
 
-gboolean
+gboolean MONO_JIT_ICALL_FP_ABI
 mono_fcgt_un (double a, double b)
 {
 	return a > b;
 }
 
-gboolean
+gboolean MONO_JIT_ICALL_FP_ABI
 mono_fclt (double a, double b)
 {
 	return a < b;
 }
 
-gboolean
+gboolean MONO_JIT_ICALL_FP_ABI
 mono_fclt_un (double a, double b)
 {
 	return a < b;
 }
 
-double
+double MONO_JIT_ICALL_FP_ABI
 mono_fload_r4 (float *ptr)
 {
 	return *ptr;
 }
 
-void
+void MONO_JIT_ICALL_FP_ABI
 mono_fstore_r4 (double val, float *ptr)
 {
 	*ptr = (float)val;
 }
 
 /* returns the integer bitpattern that is passed in the regs or stack */
-guint32
+guint32 MONO_JIT_ICALL_FP_ABI
 mono_fload_r4_arg (double val)
 {
 	float v = (float)val;
@@ -685,14 +693,14 @@ mono_ldtoken_wrapper (MonoImage *image, int token, MonoGenericContext *context)
 	return res;
 }
 
-guint64
+guint64 MONO_JIT_ICALL_FP_ABI
 mono_fconv_u8 (double v)
 {
 	return (guint64)v;
 }
 
 #ifdef MONO_ARCH_EMULATE_FCONV_TO_I8
-gint64
+gint64 MONO_JIT_ICALL_FP_ABI
 mono_fconv_i8 (double v)
 {
 	/* no need, no exceptions: MONO_ARCH_SAVE_REGS;*/
@@ -700,7 +708,7 @@ mono_fconv_i8 (double v)
 }
 #endif
 
-guint32
+guint32 MONO_JIT_ICALL_FP_ABI
 mono_fconv_u4 (double v)
 {
 	/* no need, no exceptions: MONO_ARCH_SAVE_REGS;*/
@@ -718,7 +726,7 @@ extern long double aintl (long double);
 #endif
 #endif /* HAVE_TRUNC */
 
-gint64
+gint64 MONO_JIT_ICALL_FP_ABI
 mono_fconv_ovf_i8 (double v)
 {
 	gint64 res;
@@ -733,7 +741,7 @@ mono_fconv_ovf_i8 (double v)
 	return res;
 }
 
-guint64
+guint64 MONO_JIT_ICALL_FP_ABI
 mono_fconv_ovf_u8 (double v)
 {
 	guint64 res;
@@ -749,7 +757,7 @@ mono_fconv_ovf_u8 (double v)
 }
 
 #ifdef MONO_ARCH_EMULATE_LCONV_TO_R8
-double
+double MONO_JIT_ICALL_FP_ABI
 mono_lconv_to_r8 (gint64 a)
 {
 	return (double)a;
@@ -757,15 +765,30 @@ mono_lconv_to_r8 (gint64 a)
 #endif
 
 #ifdef MONO_ARCH_EMULATE_LCONV_TO_R4
-float
+#ifdef MONO_ARCH_SOFT_FLOAT
+double MONO_JIT_ICALL_FP_ABI
+mono_lconv_to_r4 (gint64 a)
+{
+	/*
+	 * Soft-float mini represents IL evaluation-stack floating-point
+	 * values as double-width register pairs.  conv.r4 still has to round
+	 * to single precisiont.  Returning a C float here would make opcode
+	 * emulation spill through CEE_STIND_R4, which the soft-float selector
+	 * intentionally cannot lower.
+	 */
+	return (float)a;
+}
+#else
+float MONO_JIT_ICALL_FP_ABI
 mono_lconv_to_r4 (gint64 a)
 {
 	return (float)a;
 }
 #endif
+#endif
 
 #ifdef MONO_ARCH_EMULATE_CONV_R8_UN
-double
+double MONO_JIT_ICALL_FP_ABI
 mono_conv_to_r8_un (guint32 a)
 {
 	return (double)a;
@@ -773,7 +796,7 @@ mono_conv_to_r8_un (guint32 a)
 #endif
 
 #ifdef MONO_ARCH_EMULATE_LCONV_TO_R8_UN
-double
+double MONO_JIT_ICALL_FP_ABI
 mono_lconv_to_r8_un (guint64 a)
 {
 	return (double)a;

--- a/mono/mini/jit-icalls.h
+++ b/mono/mini/jit-icalls.h
@@ -5,6 +5,22 @@
 
 #include "mini.h"
 
+/*
+ * The ARM JIT in this Mono version defines MONO_ARCH_SOFT_FLOAT for EABI
+ * targets and lowers floating-point helper calls using the base AAPCS: float
+ * and double arguments/results travel through core registers.  armhf C code is
+ * compiled with the VFP procedure-call standard instead, so an unannotated C
+ * helper with a float/double in its signature expects different registers than
+ * the JIT supplies.  Mark only these JIT ABI-boundary helpers with the base
+ * AAPCS so the compiler emits entry/return code that matches the existing ARM
+ * backend, while ordinary C calls in the runtime keep using the system ABI.
+ */
+#if defined(__arm__) && defined(__GNUC__) && defined(__ARM_PCS_VFP)
+#define MONO_JIT_ICALL_FP_ABI __attribute__((pcs("aapcs")))
+#else
+#define MONO_JIT_ICALL_FP_ABI
+#endif
+
 void* mono_ldftn (MonoMethod *method) MONO_INTERNAL;
 
 void* mono_ldftn_nosync (MonoMethod *method) MONO_INTERNAL;
@@ -33,7 +49,7 @@ gint32 mono_imul_ovf (gint32 a, gint32 b) MONO_INTERNAL;
 
 gint32 mono_imul_ovf_un (guint32 a, guint32 b) MONO_INTERNAL;
 
-double mono_fdiv (double a, double b) MONO_INTERNAL;
+double MONO_JIT_ICALL_FP_ABI mono_fdiv (double a, double b) MONO_INTERNAL;
 
 gint64 mono_lldiv (gint64 a, gint64 b) MONO_INTERNAL;
 
@@ -55,27 +71,31 @@ gpointer mono_class_static_field_address (MonoDomain *domain, MonoClassField *fi
 
 gpointer mono_ldtoken_wrapper (MonoImage *image, int token, MonoGenericContext *context) MONO_INTERNAL;
 
-guint64 mono_fconv_u8 (double v) MONO_INTERNAL;
+guint64 MONO_JIT_ICALL_FP_ABI mono_fconv_u8 (double v) MONO_INTERNAL;
 
-gint64 mono_fconv_i8 (double v) MONO_INTERNAL;
+gint64 MONO_JIT_ICALL_FP_ABI mono_fconv_i8 (double v) MONO_INTERNAL;
 
-guint32 mono_fconv_u4 (double v) MONO_INTERNAL;
+guint32 MONO_JIT_ICALL_FP_ABI mono_fconv_u4 (double v) MONO_INTERNAL;
 
-gint64 mono_fconv_ovf_i8 (double v) MONO_INTERNAL;
+gint64 MONO_JIT_ICALL_FP_ABI mono_fconv_ovf_i8 (double v) MONO_INTERNAL;
 
-guint64 mono_fconv_ovf_u8 (double v) MONO_INTERNAL;
+guint64 MONO_JIT_ICALL_FP_ABI mono_fconv_ovf_u8 (double v) MONO_INTERNAL;
 
-double mono_lconv_to_r8 (gint64 a) MONO_INTERNAL;
+double MONO_JIT_ICALL_FP_ABI mono_lconv_to_r8 (gint64 a) MONO_INTERNAL;
 
-double mono_conv_to_r8 (gint32 a) MONO_INTERNAL;
+double MONO_JIT_ICALL_FP_ABI mono_conv_to_r8 (gint32 a) MONO_INTERNAL;
 
-double mono_conv_to_r4 (gint32 a) MONO_INTERNAL;
+double MONO_JIT_ICALL_FP_ABI mono_conv_to_r4 (gint32 a) MONO_INTERNAL;
 
-float mono_lconv_to_r4 (gint64 a) MONO_INTERNAL;
+#ifdef MONO_ARCH_SOFT_FLOAT
+double MONO_JIT_ICALL_FP_ABI mono_lconv_to_r4 (gint64 a) MONO_INTERNAL;
+#else
+float MONO_JIT_ICALL_FP_ABI mono_lconv_to_r4 (gint64 a) MONO_INTERNAL;
+#endif
 
-double mono_conv_to_r8_un (guint32 a) MONO_INTERNAL;
+double MONO_JIT_ICALL_FP_ABI mono_conv_to_r8_un (guint32 a) MONO_INTERNAL;
 
-double mono_lconv_to_r8_un (guint64 a) MONO_INTERNAL;
+double MONO_JIT_ICALL_FP_ABI mono_lconv_to_r8_un (guint64 a) MONO_INTERNAL;
 
 gpointer mono_helper_compile_generic_method (MonoObject *obj, MonoMethod *method, MonoGenericContext *context, gpointer *this_arg) MONO_INTERNAL;
 
@@ -85,61 +105,65 @@ MonoString *mono_helper_ldstr_mscorlib (guint32 idx) MONO_INTERNAL;
 
 MonoObject *mono_helper_newobj_mscorlib (guint32 idx) MONO_INTERNAL;
 
-double mono_fsub (double a, double b) MONO_INTERNAL;
+double MONO_JIT_ICALL_FP_ABI mono_fsub (double a, double b) MONO_INTERNAL;
 
-double mono_fadd (double a, double b) MONO_INTERNAL;
+double MONO_JIT_ICALL_FP_ABI mono_fadd (double a, double b) MONO_INTERNAL;
 
-double mono_fmul (double a, double b) MONO_INTERNAL;
+double MONO_JIT_ICALL_FP_ABI mono_fmul (double a, double b) MONO_INTERNAL;
 
-double mono_fneg (double a) MONO_INTERNAL;
+double MONO_JIT_ICALL_FP_ABI mono_fneg (double a) MONO_INTERNAL;
 
-double mono_fconv_r4 (double a) MONO_INTERNAL;
+double MONO_JIT_ICALL_FP_ABI mono_fconv_r4 (double a) MONO_INTERNAL;
 
-gint8 mono_fconv_i1 (double a) MONO_INTERNAL;
+gint8 MONO_JIT_ICALL_FP_ABI mono_fconv_i1 (double a) MONO_INTERNAL;
 
-gint16 mono_fconv_i2 (double a) MONO_INTERNAL;
+gint16 MONO_JIT_ICALL_FP_ABI mono_fconv_i2 (double a) MONO_INTERNAL;
 
-gint32 mono_fconv_i4 (double a) MONO_INTERNAL;
+gint32 MONO_JIT_ICALL_FP_ABI mono_fconv_i4 (double a) MONO_INTERNAL;
 
-guint8 mono_fconv_u1 (double a) MONO_INTERNAL;
+guint8 MONO_JIT_ICALL_FP_ABI mono_fconv_u1 (double a) MONO_INTERNAL;
 
-guint16 mono_fconv_u2 (double a) MONO_INTERNAL;
+guint16 MONO_JIT_ICALL_FP_ABI mono_fconv_u2 (double a) MONO_INTERNAL;
 
-gboolean mono_fcmp_eq (double a, double b) MONO_INTERNAL;
+gboolean MONO_JIT_ICALL_FP_ABI mono_fcmp_eq (double a, double b) MONO_INTERNAL;
 
-gboolean mono_fcmp_ge (double a, double b) MONO_INTERNAL;
+gboolean MONO_JIT_ICALL_FP_ABI mono_fcmp_ge (double a, double b) MONO_INTERNAL;
 
-gboolean mono_fcmp_gt (double a, double b) MONO_INTERNAL;
+gboolean MONO_JIT_ICALL_FP_ABI mono_fcmp_gt (double a, double b) MONO_INTERNAL;
 
-gboolean mono_fcmp_le (double a, double b) MONO_INTERNAL;
+gboolean MONO_JIT_ICALL_FP_ABI mono_fcmp_le (double a, double b) MONO_INTERNAL;
 
-gboolean mono_fcmp_lt (double a, double b) MONO_INTERNAL;
+gboolean MONO_JIT_ICALL_FP_ABI mono_fcmp_lt (double a, double b) MONO_INTERNAL;
 
-gboolean mono_fcmp_ne_un (double a, double b) MONO_INTERNAL;
+gboolean MONO_JIT_ICALL_FP_ABI mono_fcmp_ne_un (double a, double b) MONO_INTERNAL;
 
-gboolean mono_fcmp_ge_un (double a, double b) MONO_INTERNAL;
+gboolean MONO_JIT_ICALL_FP_ABI mono_fcmp_ge_un (double a, double b) MONO_INTERNAL;
 
-gboolean mono_fcmp_gt_un (double a, double b) MONO_INTERNAL;
+gboolean MONO_JIT_ICALL_FP_ABI mono_fcmp_gt_un (double a, double b) MONO_INTERNAL;
 
-gboolean mono_fcmp_le_un (double a, double b) MONO_INTERNAL;
+gboolean MONO_JIT_ICALL_FP_ABI mono_fcmp_le_un (double a, double b) MONO_INTERNAL;
 
-gboolean mono_fcmp_lt_un (double a, double b) MONO_INTERNAL;
+gboolean MONO_JIT_ICALL_FP_ABI mono_fcmp_lt_un (double a, double b) MONO_INTERNAL;
 
-gboolean mono_fceq (double a, double b) MONO_INTERNAL;
+gboolean MONO_JIT_ICALL_FP_ABI mono_fceq (double a, double b) MONO_INTERNAL;
 
-gboolean mono_fcgt (double a, double b) MONO_INTERNAL;
+gboolean MONO_JIT_ICALL_FP_ABI mono_fcgt (double a, double b) MONO_INTERNAL;
 
-gboolean mono_fcgt_un (double a, double b) MONO_INTERNAL;
+gboolean MONO_JIT_ICALL_FP_ABI mono_fcgt_un (double a, double b) MONO_INTERNAL;
 
-gboolean mono_fclt (double a, double b) MONO_INTERNAL;
+gboolean MONO_JIT_ICALL_FP_ABI mono_fclt (double a, double b) MONO_INTERNAL;
 
-gboolean mono_fclt_un (double a, double b) MONO_INTERNAL;
+gboolean MONO_JIT_ICALL_FP_ABI mono_fclt_un (double a, double b) MONO_INTERNAL;
 
-double   mono_fload_r4 (float *ptr);
+double   MONO_JIT_ICALL_FP_ABI mono_fload_r4 (float *ptr);
 
-void     mono_fstore_r4 (double val, float *ptr);
+void     MONO_JIT_ICALL_FP_ABI mono_fstore_r4 (double val, float *ptr);
 
-guint32  mono_fload_r4_arg (double val);
+guint32  MONO_JIT_ICALL_FP_ABI mono_fload_r4_arg (double val);
+
+#if defined(__arm__) && defined(__ARM_PCS_VFP)
+double MONO_JIT_ICALL_FP_ABI mono_frem (double a, double b) MONO_INTERNAL;
+#endif
 
 #endif /* __MONO_JIT_ICALLS_H__ */
 

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -12341,13 +12341,29 @@ mini_init (const char *filename, const char *runtime_version)
 	mono_register_opcode_emulation (OP_LCONV_TO_R8, "__emul_lconv_to_r8", "double long", mono_lconv_to_r8, FALSE);
 #endif
 #ifdef MONO_ARCH_EMULATE_LCONV_TO_R4
+#ifdef MONO_ARCH_SOFT_FLOAT
+	/*
+	 * The soft-float backend carries IL F values in double-width register
+	 * pairs.  lconv.r4 rounds to single precision, but the emulation
+	 * helper must still return the internal F representation.  A "float"
+	 * helper return would force mono_emulate_opcode() to spill through
+	 * CEE_STIND_R4, which is only valid for storage and is not lowerable
+	 * by the soft-float instruction selector.
+	 */
+	mono_register_opcode_emulation (OP_LCONV_TO_R4, "__emul_lconv_to_r4", "double long", mono_lconv_to_r4, FALSE);
+#else
 	mono_register_opcode_emulation (OP_LCONV_TO_R4, "__emul_lconv_to_r4", "float long", mono_lconv_to_r4, FALSE);
+#endif
 #endif
 #ifdef MONO_ARCH_EMULATE_LCONV_TO_R8_UN
 	mono_register_opcode_emulation (OP_LCONV_TO_R_UN, "__emul_lconv_to_r8_un", "double long", mono_lconv_to_r8_un, FALSE);
 #endif
 #ifdef MONO_ARCH_EMULATE_FREM
+#if defined(__arm__) && defined(__ARM_PCS_VFP)
+	mono_register_opcode_emulation (OP_FREM, "__emul_frem", "double double double", mono_frem, FALSE);
+#else
 	mono_register_opcode_emulation (OP_FREM, "__emul_frem", "double double double", fmod, FALSE);
+#endif
 #endif
 
 #ifdef MONO_ARCH_SOFT_FLOAT

--- a/mono/utils/mono-compiler.h
+++ b/mono/utils/mono-compiler.h
@@ -108,5 +108,19 @@
 #define MONO_INTERNAL 
 #endif
 
-#endif /* __UTILS_MONO_COMPILER_H__*/
+/*
+ * Mono 1.2.6's ARM EABI backend defines MONO_ARCH_SOFT_FLOAT and emits managed
+ * internal-call wrappers that pass and return floating-point values in core
+ * registers.  On armhf, the C compiler uses the VFP procedure-call standard for
+ * ordinary C functions, which uses VFP registers for non-variadic float/double
+ * arguments and return values.  Mark C internal-call entry points that expose
+ * float/double in their native signatures with the base AAPCS so the generated
+ * managed wrapper and native function agree at that ABI boundary.
+ */
+#if defined(__arm__) && defined(__GNUC__) && defined(__ARM_PCS_VFP)
+#define MONO_ICALL_FP_ABI __attribute__((pcs("aapcs")))
+#else
+#define MONO_ICALL_FP_ABI
+#endif
 
+#endif /* __UTILS_MONO_COMPILER_H__*/


### PR DESCRIPTION
Mono 1.2.6's ARM EABI backend defines MONO_ARCH_SOFT_FLOAT and emits managed floating-point helper/internal-call boundaries using the base AAPCS convention: float and double values cross those boundaries in core registers.  On armhf, normal C functions are compiled with the VFP procedure-call standard, so unannotated C functions with float/double arguments or return values use VFP registers instead.  That makes the generated managed/JIT caller and the native C callee disagree about where the value is.

JIT floating-point helper calls are generated by the old ARM backend using the soft-float managed ABI.  Mark only those helper entry points with pcs("aapcs") when compiling C code for ARM hard-float.  This preserves the system ABI for ordinary runtime C calls while making helper calls match the code the JIT actually emits.

Metadata internal calls are wrapped as managed-to-native calli stubs.  On the backend, those wrappers use the same soft-float managed calling model as JIT helpers.  Decimal double conversion, System.Math, and floating Interlocked icalls therefore need the same ABI bridge whenever their native signatures contain float or double.  This fixes Decimal conversion at the runtime ABI boundary.

Under MONO_ARCH_SOFT_FLOAT, Mono represents evaluation-stack floating-point values as double-width register-pair values.  lconv.r4 must round to single precision, but still return the internal floating representation.  Returning a C float from the helper causes the soft-float selector to spill through an ARM-JIT-unsupported stind.r4 path.  Return double while explicitly rounding through float.

On ARM hard-float, frem must go through a JIT helper with the same ABI annotation as the other floating helpers.